### PR TITLE
Flink compaction filter to clean up expired state entries with time-to-live

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ set(SOURCES
         utilities/env_mirror.cc
         utilities/env_timed.cc
         utilities/geodb/geodb_impl.cc
+        utilities/flink/flink_compaction_filter.cc
         utilities/leveldb_options/leveldb_options.cc
         utilities/lua/rocks_lua_compaction_filter.cc
         utilities/memory/memory_util.cc
@@ -957,6 +958,7 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_format_test.cc
         utilities/cassandra/cassandra_row_merge_test.cc
         utilities/cassandra/cassandra_serialize_test.cc
+        utilities/flink/flink_compaction_filter_test.cc
         utilities/checkpoint/checkpoint_test.cc
         utilities/column_aware_encoding_test.cc
         utilities/date_tiered/date_tiered_test.cc

--- a/Makefile
+++ b/Makefile
@@ -488,6 +488,7 @@ TESTS = \
 	compaction_picker_test \
 	version_builder_test \
 	file_indexer_test \
+	flink_compaction_filter_test \
 	write_batch_test \
 	write_batch_with_index_test \
 	write_controller_test\
@@ -1130,6 +1131,9 @@ cassandra_serialize_test: utilities/cassandra/cassandra_serialize_test.o $(LIBOB
 	$(AM_LINK)
 
 redis_test: utilities/redis/redis_lists_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+flink_compaction_filter_test: utilities/flink/flink_compaction_filter_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 hash_table_test: utilities/persistent_cache/hash_table_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -254,6 +254,7 @@ cpp_library(
         "utilities/env_mirror.cc",
         "utilities/env_timed.cc",
         "utilities/geodb/geodb_impl.cc",
+        "utilities/flink/flink_compaction_filter.cc",
         "utilities/leveldb_options/leveldb_options.cc",
         "utilities/lua/rocks_lua_compaction_filter.cc",
         "utilities/memory/memory_util.cc",
@@ -313,6 +314,7 @@ cpp_library(
         "utilities/col_buf_decoder.cc",
         "utilities/col_buf_encoder.cc",
         "utilities/column_aware_encoding_util.cc",
+        "utilities/flink/flink_compaction_filter.cc",
     ],
     auto_headers = AutoHeaders.RECURSIVE_GLOB,
     arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
@@ -744,6 +746,11 @@ ROCKS_TESTS = [
         "filename_test",
         "db/filename_test.cc",
         "serial",
+    ],
+    [
+            "flink_compaction_filter_test",
+            "utilities/flink/flink_compaction_filter_test.cc",
+            "serial",
     ],
     [
         "flush_job_test",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 4096
+    v.memory = 6096
     v.cpus = 2
   end
 

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -19,6 +19,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/compression_options.cc
         rocksjni/env.cc
         rocksjni/env_options.cc
+        rocksjni/flink_compactionfilterjni.cc
         rocksjni/filter.cc
         rocksjni/ingest_external_file_options.cc
         rocksjni/iterator.cc
@@ -90,6 +91,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.Env
         org.rocksdb.EnvOptions
         org.rocksdb.Filter
+        org.rocksdb.FlinkCompactionFilter
         org.rocksdb.FlushOptions
         org.rocksdb.HashLinkedListMemTableConfig
         org.rocksdb.HashSkipListMemTableConfig
@@ -212,6 +214,7 @@ add_jar(
   src/main/java/org/rocksdb/EnvOptions.java
   src/main/java/org/rocksdb/Experimental.java
   src/main/java/org/rocksdb/Filter.java
+  src/main/java/org/rocksdb/FlinkCompactionFilter.java
   src/main/java/org/rocksdb/FlushOptions.java
   src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
   src/main/java/org/rocksdb/HashSkipListMemTableConfig.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -23,6 +23,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.DirectSlice\
 	org.rocksdb.Env\
 	org.rocksdb.EnvOptions\
+	org.rocksdb.FlinkCompactionFilter\
 	org.rocksdb.FlushOptions\
 	org.rocksdb.Filter\
 	org.rocksdb.IngestExternalFileOptions\

--- a/java/crossbuild/Vagrantfile
+++ b/java/crossbuild/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
+    v.memory = 6048
     v.cpus = 4
     v.customize ["modifyvm", :id, "--nictype1", "virtio" ]
   end

--- a/java/crossbuild/Vagrantfile
+++ b/java/crossbuild/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 6048
+    v.memory = 2048
     v.cpus = 4
     v.customize ["modifyvm", :id, "--nictype1", "virtio" ]
   end

--- a/java/rocksjni/flink_compactionfilterjni.cc
+++ b/java/rocksjni/flink_compactionfilterjni.cc
@@ -26,6 +26,9 @@ protected:
   }
 };
 
+// This list element filter operates on list state for which byte length of elements is unknown (variable),
+// the list element serializer has to be used in this case to compute the offset of the next element.
+// The filter wraps java object implenented in Flink. The java object holds element serializer and performs filtering.
 class JavaListElementFilter : public rocksdb::flink::FlinkCompactionFilter::ListElementFilter, JniCallbackBase {
 public:
   JavaListElementFilter(JNIEnv* env, jobject jlist_filter) : JniCallbackBase(env, jlist_filter) {

--- a/java/rocksjni/flink_compactionfilterjni.cc
+++ b/java/rocksjni/flink_compactionfilterjni.cc
@@ -1,0 +1,62 @@
+#include <climits>// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <jni.h>
+
+#include "include/org_rocksdb_FlinkCompactionFilter.h"
+#include "utilities/flink/flink_compaction_filter.h"
+#include "rocksjni/jnicallback.h"
+
+#define TIME_PROVIDER_METHOD "currentTimestamp"
+#define JTIME_PROVIDER_CLASS "org/rocksdb/FlinkCompactionFilter$TimeProvider"
+
+/**
+ * Wrapper around org/rocksdb/FlinkCompactionFilter$TimeProvider::currentTimestamp method.
+ */
+class FlinkTimeProvider : rocksdb::JniCallback, public rocksdb::flink::TimeProvider {
+  public:
+    FlinkTimeProvider(JNIEnv* env, jobject jtime_provider) : JniCallback(env, jtime_provider) {
+      jclass jcls = env->FindClass(JTIME_PROVIDER_CLASS);
+      assert(jcls != nullptr);
+      m_jcurrent_timestamp_method_methodid = env->GetMethodID(jcls, TIME_PROVIDER_METHOD, "()J");
+      assert(m_jcurrent_timestamp_method_methodid != nullptr);
+    }
+
+    int64_t CurrentTimestamp() const override {
+      jboolean attached_thread = JNI_FALSE;
+      JNIEnv* env = getJniEnv(&attached_thread);
+      assert(env != nullptr);
+
+      jlong ts = env->CallLongMethod(m_jcallback_obj, m_jcurrent_timestamp_method_methodid);
+
+      if(env->ExceptionCheck()) {
+          // exception thrown from CallVoidMethod
+          env->ExceptionDescribe();  // print out exception to stderr
+          ts = 0;
+      }
+      releaseJniEnv(attached_thread);
+      return static_cast<int64_t>(ts);
+    };
+
+  private:
+    jmethodID m_jcurrent_timestamp_method_methodid;
+};
+
+/*
+ * Class:     org_rocksdb_FlinkCompactionFilter
+ * Method:    createNewFlinkCompactionFilter0
+ * Signature: (Ljava/lang/Object;IJZ)J
+ */
+jlong  __unused Java_org_rocksdb_FlinkCompactionFilter_createNewFlinkCompactionFilter0(
+    JNIEnv* env, jclass /* jcls */, jobject jtime_provider, jint ji_state_type, jlong jl_ttl_milli, jboolean use_system_time) {
+  using namespace rocksdb::flink;
+  auto state_type = static_cast<FlinkCompactionFilter::StateType>(ji_state_type);
+  auto ttl = static_cast<int64_t>(jl_ttl_milli);
+  auto* compaction_filter = (bool)(use_system_time == JNI_TRUE) ?
+    new FlinkCompactionFilter(state_type, ttl) :
+    new FlinkCompactionFilter(state_type, ttl, new FlinkTimeProvider(env, jtime_provider));
+  // set the native handle to our native compaction filter
+  return reinterpret_cast<jlong>(compaction_filter);
+}

--- a/java/rocksjni/flink_compactionfilterjni.cc
+++ b/java/rocksjni/flink_compactionfilterjni.cc
@@ -164,7 +164,8 @@ jlong Java_org_rocksdb_FlinkCompactionFilter_configureFlinkCompactionFilter(
   auto use_system_time = (bool)(jb_use_system_time == JNI_TRUE);
   auto config_holder = *(reinterpret_cast<std::shared_ptr<FlinkCompactionFilter::ConfigHolder>*>(handle));
   auto list_iter_factory = createListElementIterFactory(env, ji_list_elem_len, jlist_iter_factory);
-  config_holder->Configure(FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, use_system_time, list_iter_factory});
+  auto config = new FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, use_system_time, list_iter_factory};
+  config_holder->Configure(config);
   return handle;
 }
 

--- a/java/rocksjni/flink_compactionfilterjni.cc
+++ b/java/rocksjni/flink_compactionfilterjni.cc
@@ -10,51 +10,102 @@
 #include "utilities/flink/flink_compaction_filter.h"
 #include "rocksjni/jnicallback.h"
 #include "loggerjnicallback.h"
+#include "portal.h"
 
-//
-// Simple logger that prints message on stdout
-//
-class ConsoleLogger : public rocksdb::Logger {
+using namespace rocksdb::flink;
+
+class JavaListElementIter : public rocksdb::flink::FlinkCompactionFilter::ListElementIter, rocksdb::JniCallback {
 public:
-    using Logger::Logv;
-    explicit ConsoleLogger(rocksdb::InfoLogLevel logLevel) : Logger(logLevel) {}
+  JavaListElementIter(JNIEnv* env, jobject jlist_iter) : JniCallback(env, jlist_iter) {
+      jclass jclazz = rocksdb::JavaClass::getJClass(env, "org/rocksdb/FlinkCompactionFilter$ListElementIter");
+      if(jclazz == nullptr) {
+        // exception occurred accessing class
+        return;
+      }
+      m_jset_list_data_methodid = env->GetMethodID(jclazz, "setListBytes", "([B)V");
+      assert(m_jset_list_data_methodid != nullptr);
+      m_jnext_offset_methodid = env->GetMethodID(jclazz, "nextOffset", "(I)I");
+      assert(m_jnext_offset_methodid != nullptr);
 
-    void Logv(const char* format, va_list ap) override {
-        vprintf(format, ap);
-        printf("\n");
+  }
+
+  inline void SetListBytes(const rocksdb::Slice& list) const override {
+    jboolean attached_thread = JNI_FALSE;
+    JNIEnv* env = getJniEnv(&attached_thread);
+    jbyteArray jlist = rocksdb::JniUtil::copyBytes(env, list);
+    CheckAndRethrowException(env);
+    if (jlist == nullptr) {
+      return;
     }
+    env->CallVoidMethod(m_jcallback_obj, m_jset_list_data_methodid, jlist);
+    CheckAndRethrowException(env);
+    env->DeleteLocalRef(jlist);
+    releaseJniEnv(attached_thread);
+  };
+
+  inline std::size_t NextOffset(std::size_t current_offset) const override {
+    jboolean attached_thread = JNI_FALSE;
+    JNIEnv* env = getJniEnv(&attached_thread);
+    auto ji_current_offset = static_cast<jint>(current_offset);
+    jint next_offset = env->CallIntMethod(m_jcallback_obj, m_jnext_offset_methodid, ji_current_offset);
+    CheckAndRethrowException(env);
+    releaseJniEnv(attached_thread);
+    return static_cast<std::size_t>(next_offset);
+  };
+
+private:
+  inline void CheckAndRethrowException(JNIEnv* env) const {
+    if (env->ExceptionCheck()) {
+      env->ExceptionDescribe();
+      env->Throw(env->ExceptionOccurred());
+    }
+  }
+
+  jmethodID m_jset_list_data_methodid;
+  jmethodID m_jnext_offset_methodid;
 };
+
+static FlinkCompactionFilter::ListElementIter* createListElementIter(JNIEnv* env, jint ji_list_elem_len, jobject jlist_iter) {
+  FlinkCompactionFilter::ListElementIter* list_iter = nullptr;
+  if (ji_list_elem_len > 0) {
+    std::size_t fixed_size = static_cast<std::size_t>(ji_list_elem_len);
+    list_iter = new FlinkCompactionFilter::FixedListElementIter(fixed_size);
+  } else if (jlist_iter != nullptr) {
+    list_iter = new JavaListElementIter(env, jlist_iter);
+  }
+  return list_iter;
+}
 
 /*
  * Class:     org_rocksdb_FlinkCompactionFilter
  * Method:    createNewFlinkCompactionFilter0
- * Signature: (B)J
+ * Signature: (J)J
  */
 jlong Java_org_rocksdb_FlinkCompactionFilter_createNewFlinkCompactionFilter0(
-        JNIEnv* /* env */, jclass /* jcls */, jbyte jlog_level) {
+        JNIEnv* /* env */, jclass /* jcls */, jlong logger_handle) {
   using namespace rocksdb::flink;
-  // set the native handle to our native compaction filter
-  auto* logger= new ConsoleLogger(static_cast<rocksdb::InfoLogLevel>(jlog_level));
+  auto logger = logger_handle == 0 ? nullptr :
+          *(reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(logger_handle));
   return reinterpret_cast<jlong>(new FlinkCompactionFilter(logger));
 }
 
 /*
  * Class:     org_rocksdb_FlinkCompactionFilter
  * Method:    configureFlinkCompactionFilter
- * Signature: (JIIJZJ)J
+ * Signature: (JIIJZILorg/rocksdb/FlinkCompactionFilter$ListElementIter;)J
  */
 jlong Java_org_rocksdb_FlinkCompactionFilter_configureFlinkCompactionFilter(
-        JNIEnv* /* env */, jclass /* jcls */,
+        JNIEnv* env, jclass /* jcls */,
         jlong handle, jint ji_state_type, jint ji_timestamp_offset,
-        jlong jl_ttl_milli, jboolean jb_use_system_time) {
-    using namespace rocksdb::flink;
-    auto state_type = static_cast<FlinkCompactionFilter::StateType>(ji_state_type);
-    auto timestamp_offset = static_cast<size_t>(ji_timestamp_offset);
-    auto ttl = static_cast<int64_t>(jl_ttl_milli);
-    auto use_system_time = (bool)(jb_use_system_time == JNI_TRUE);
-    auto filter = reinterpret_cast<FlinkCompactionFilter*>(handle);
-    filter->Configure(new FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, use_system_time});
-    return handle;
+        jlong jl_ttl_milli, jboolean jb_use_system_time, jint ji_list_elem_len, jobject jlist_iter) {
+  auto state_type = static_cast<FlinkCompactionFilter::StateType>(ji_state_type);
+  auto timestamp_offset = static_cast<size_t>(ji_timestamp_offset);
+  auto ttl = static_cast<int64_t>(jl_ttl_milli);
+  auto use_system_time = (bool)(jb_use_system_time == JNI_TRUE);
+  auto filter = reinterpret_cast<FlinkCompactionFilter*>(handle);
+  auto list_iter = createListElementIter(env, ji_list_elem_len, jlist_iter);
+  filter->Configure(new FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, use_system_time, list_iter});
+  return handle;
 }
 
 /*
@@ -64,9 +115,9 @@ jlong Java_org_rocksdb_FlinkCompactionFilter_configureFlinkCompactionFilter(
  */
 jlong Java_org_rocksdb_FlinkCompactionFilter_setCurrentTimestamp(
         JNIEnv* /* env */, jclass /* jcls */, jlong handle, jlong jl_current_timestamp) {
-    using namespace rocksdb::flink;
-    auto filter = reinterpret_cast<FlinkCompactionFilter*>(handle);
-    auto current_timestamp = static_cast<int64_t>(jl_current_timestamp);
-    filter->SetCurrentTimestamp(current_timestamp);
-    return handle;
+  using namespace rocksdb::flink;
+  auto filter = reinterpret_cast<FlinkCompactionFilter*>(handle);
+  auto current_timestamp = static_cast<int64_t>(jl_current_timestamp);
+  filter->SetCurrentTimestamp(current_timestamp);
+  return handle;
 }

--- a/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
@@ -38,6 +38,10 @@ public class FlinkCompactionFilter
     /**
      * Gets offset of the first unexpired element in the list.
      *
+     * <p>Native code wraps this java object and calls it for list state
+     * for which element byte length is unknown and Flink custom type serializer has to be used
+     * to compute offset of the next element in serialized form.
+     *
      * @param list serialised list of elements with timestamp
      * @param ttl time-to-live of the list elements
      * @param currentTimestamp current timestamp to check expiration against
@@ -56,6 +60,7 @@ public class FlinkCompactionFilter
     final StateType stateType;
     final int timestampOffset;
     final long ttl;
+    /** Number of state entries to process by compaction filter before updating current timestamp. */
     final long queryTimeAfterNumEntries;
     final int fixedElementLength;
     final ListElementFilterFactory listElementFilterFactory;

--- a/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
@@ -14,25 +14,29 @@ public class FlinkCompactionFilter
     // WARNING!!! Do not change the order of enum entries as it is important for jni translation
     Value,
     List,
-    Map
+    Map,
+    Disabled
   }
 
-  public interface TimeProvider {
-    long currentTimestamp();
+  public FlinkCompactionFilter() {
+    super(createNewFlinkCompactionFilter0(InfoLogLevel.ERROR_LEVEL.getValue()));
   }
 
-  private final TimeProvider timeProvider;
-
-  public FlinkCompactionFilter(StateType stateType, long ttl, TimeProvider timeProvider) {
-    super(createNewFlinkCompactionFilter0(timeProvider, stateType.ordinal(), ttl, timeProvider == null));
-    this.timeProvider = timeProvider;
+  public FlinkCompactionFilter(InfoLogLevel logLevel) {
+    super(createNewFlinkCompactionFilter0(logLevel.getValue()));
   }
 
-  @SuppressWarnings("unused")
-  public long currentTimestamp() {
-    return timeProvider.currentTimestamp();
+  public void configure(StateType stateType, int timestampOffset, long ttl, boolean useSystemTime) {
+    configureFlinkCompactionFilter(nativeHandle_, stateType.ordinal(), timestampOffset, ttl, useSystemTime);
   }
 
-  private native static long createNewFlinkCompactionFilter0(
-          Object filter, int stateType, long ttl, boolean useSystemTime);
+  public void setCurrentTimestamp(long currentTimestamp) {
+    setCurrentTimestamp(nativeHandle_, currentTimestamp);
+  }
+
+  private native static long createNewFlinkCompactionFilter0(byte logLevel);
+  private native static long configureFlinkCompactionFilter(
+          long filterHandle, int stateType, int timestampOffset, long ttl, boolean useSystemTime);
+  private native static long setCurrentTimestamp(
+          long filterHandle, long currentTimestamp);
 }

--- a/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
@@ -1,0 +1,38 @@
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Just a Java wrapper around FlinkCompactionFilter implemented in C++
+ */
+public class FlinkCompactionFilter
+    extends AbstractCompactionFilter<Slice> {
+  public enum StateType {
+    // WARNING!!! Do not change the order of enum entries as it is important for jni translation
+    Value,
+    List,
+    Map
+  }
+
+  public interface TimeProvider {
+    long currentTimestamp();
+  }
+
+  private final TimeProvider timeProvider;
+
+  public FlinkCompactionFilter(StateType stateType, long ttl, TimeProvider timeProvider) {
+    super(createNewFlinkCompactionFilter0(timeProvider, stateType.ordinal(), ttl, timeProvider == null));
+    this.timeProvider = timeProvider;
+  }
+
+  @SuppressWarnings("unused")
+  public long currentTimestamp() {
+    return timeProvider.currentTimestamp();
+  }
+
+  private native static long createNewFlinkCompactionFilter0(
+          Object filter, int stateType, long ttl, boolean useSystemTime);
+}

--- a/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/FlinkCompactionFilter.java
@@ -37,18 +37,15 @@ public class FlinkCompactionFilter
           long configHolderHandle, long currentTimestamp);
 
   public interface ListElementIter {
-    void setListBytes(byte[] list);
-    int nextOffset(int currentOffset);
-  }
-
-  public static abstract class AbstractListElementIter implements ListElementIter {
-    protected byte[] list;
-
-    @Override
-    public void setListBytes(byte[] list) {
-      assert list != null;
-      this.list = list;
-    }
+    /**
+     * Gets offset of the first unexpired element in the list.
+     *
+     * @param list serialised list of elements with timestamp
+     * @param ttl time-to-live of the list elements
+     * @param currentTimestamp current timestamp to check expiration against
+     * @return offset of the first unexpired element in the list
+     */
+    int nextUnexpiredOffset(byte[] list, long ttl, long currentTimestamp);
   }
 
   public interface ListElementIterFactory {

--- a/java/src/test/java/org/rocksdb/FilterTest.java
+++ b/java/src/test/java/org/rocksdb/FilterTest.java
@@ -16,7 +16,7 @@ public class FilterTest {
 
   @Test
   public void filter() {
-    // new Bloom filter
+    // new Bloom filterFactory
     final BlockBasedTableConfig blockConfig = new BlockBasedTableConfig();
     try(final Options options = new Options()) {
 

--- a/java/src/test/java/org/rocksdb/FlinkCompactionFilterTest.java
+++ b/java/src/test/java/org/rocksdb/FlinkCompactionFilterTest.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rocksdb;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.FlinkCompactionFilter.StateType;
+import org.rocksdb.FlinkCompactionFilter.TimeProvider;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlinkCompactionFilterTest {
+    private static final String MERGE_OPERATOR_NAME = "stringappendtest";
+    private static final byte DELIMITER = ',';
+    private static final long TTL = 100;
+
+    private TestTimeProvider timeProvider;
+    private List<StateContext> stateContexts;
+    private List<ColumnFamilyDescriptor> cfDescs;
+    private List<ColumnFamilyHandle> cfHandles;
+
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Before
+    public void init() {
+        timeProvider = new TestTimeProvider();
+        stateContexts = new ArrayList<>(StateType.values().length);
+        cfDescs = new ArrayList<>();
+        cfHandles = new ArrayList<>();
+        cfDescs.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+        for (StateType type : StateType.values()) {
+            StateContext stateContext = StateContext.create(type, timeProvider);
+            stateContexts.add(stateContext);
+            cfDescs.add(stateContext.getCfDesc());
+        }
+    }
+
+    @After
+    public void cleanup() {
+        for (StateContext stateContext : stateContexts) {
+            stateContext.cfDesc.getOptions().close();
+            stateContext.filter.close();
+        }
+    }
+
+    @Test
+    public void checkStateTypeEnumOrder() {
+        // if the order changes it also needs to be adjusted
+        // in utilities/flink/flink_compaction_filter.h
+        // and in utilities/flink/flink_compaction_filter_test.cc
+        assertThat(StateType.Value.ordinal()).isEqualTo(0);
+        assertThat(StateType.List.ordinal()).isEqualTo(1);
+        assertThat(StateType.Map.ordinal()).isEqualTo(2);
+    }
+
+    @Test
+    public void testCompactionFilter() throws RocksDBException {
+        try(DBOptions options = createDbOptions();
+            RocksDB rocksDb = setupDb(options)) {
+            try {
+                for (StateContext stateContext : stateContexts) {
+                    stateContext.updateValueWithTimestamp(rocksDb);
+                    assertThat(stateContext.getValueWithTimestamp(rocksDb)).isEqualTo(stateContext.unexpiredValue());
+                    rocksDb.compactRange(stateContext.columnFamilyHandle);
+                    assertThat(stateContext.getValueWithTimestamp(rocksDb)).isEqualTo(stateContext.unexpiredValue());
+                }
+
+                timeProvider.expire();
+
+                for (StateContext stateContext : stateContexts) {
+                    assertThat(stateContext.getValueWithTimestamp(rocksDb)).isEqualTo(stateContext.unexpiredValue());
+                    rocksDb.compactRange(stateContext.columnFamilyHandle);
+                    assertThat(stateContext.getValueWithTimestamp(rocksDb)).isEqualTo(stateContext.expiredValue());
+                    rocksDb.compactRange(stateContext.columnFamilyHandle);
+                }
+            } finally {
+                for (ColumnFamilyHandle cfHandle : cfHandles) {
+                    cfHandle.close();
+                }
+            }
+        }
+    }
+
+    private static DBOptions createDbOptions() {
+        return new DBOptions()
+                .setCreateIfMissing(true)
+                .setCreateMissingColumnFamilies(true);
+    }
+
+    private RocksDB setupDb(DBOptions options) throws RocksDBException {
+        RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(), cfDescs, cfHandles);
+        for (int i = 0; i < stateContexts.size(); i++) {
+            stateContexts.get(i).columnFamilyHandle = cfHandles.get(i + 1);
+        }
+        return db;
+    }
+
+    private static class TestTimeProvider implements TimeProvider {
+        long time = 0;
+
+        @Override
+        public long currentTimestamp() {
+            return time;
+        }
+
+        void expire() {
+            time += TTL + TTL / 2;
+        }
+    }
+
+    private static class StateContext {
+        private static final int LONG_LENGTH = 8;
+
+        private final String cf;
+        final String key;
+        final ColumnFamilyDescriptor cfDesc;
+        final String userValue;
+        final long currentTime;
+        final FlinkCompactionFilter filter;
+
+        ColumnFamilyHandle columnFamilyHandle;
+
+        static StateContext create(StateType type, TimeProvider timeProvider) {
+            if (type == StateType.Map) {
+                return new MapStateContext(timeProvider);
+            } else if (type == StateType.List) {
+                return new ListStateContext(timeProvider);
+            } else {
+                return new StateContext(type, timeProvider);
+            }
+        }
+
+        private StateContext(StateType type, TimeProvider timeProvider) {
+            this.currentTime = timeProvider.currentTimestamp();
+            userValue = type.name() + "StateValue";
+            cf = type.name() + "StateCf";
+            key = type.name() + "StateKey";
+            filter = new FlinkCompactionFilter(type, TTL, timeProvider);
+            cfDesc = new ColumnFamilyDescriptor(getASCII(cf), getOptionsWithFilter(filter));
+        }
+
+        private static ColumnFamilyOptions getOptionsWithFilter(FlinkCompactionFilter filter) {
+            return new ColumnFamilyOptions()
+                    .setCompactionFilter(filter)
+                    .setMergeOperatorName(MERGE_OPERATOR_NAME);
+        }
+
+        private static byte[] getASCII(String str) {
+            return str.getBytes(StandardCharsets.US_ASCII);
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        ColumnFamilyDescriptor getCfDesc() {
+            return cfDesc;
+        }
+
+        byte[] getValueWithTimestamp(RocksDB db) throws RocksDBException {
+            return db.get(columnFamilyHandle, getASCII(key));
+        }
+
+        void updateValueWithTimestamp(RocksDB db) throws RocksDBException {
+            db.put(columnFamilyHandle, getASCII(key), valueWithTimestamp());
+        }
+
+        byte[] valueWithTimestamp() {
+            return valueWithTimestamp(0);
+        }
+
+        byte[] valueWithTimestamp(int offset) {
+            return valueWithTimestamp(offset, currentTime);
+        }
+
+        byte[] valueWithTimestamp(int offset, long timestamp) {
+            ByteBuffer buffer = getByteBuffer(offset);
+            buffer.put(new byte[offset]);
+            appendValueWithTimestamp(buffer, userValue, timestamp);
+            return buffer.array();
+        }
+
+        ByteBuffer getByteBuffer(int offset) {
+            int length = offset + LONG_LENGTH + userValue.length();
+            return ByteBuffer.allocate(length);
+        }
+
+        void appendValueWithTimestamp(ByteBuffer buffer, String value, long timestamp) {
+            buffer.putLong(timestamp);
+            buffer.put(getASCII(value));
+        }
+
+        byte[] unexpiredValue() {
+            return valueWithTimestamp();
+        }
+
+        byte[] expiredValue() {
+            return null;
+        }
+
+        private static class MapStateContext extends StateContext {
+            private static final int MAP_NULL_VALUE_OFFSET = 1;
+
+            private MapStateContext(TimeProvider timeProvider) {
+                super(StateType.Map, timeProvider);
+            }
+
+            @Override
+            public byte[] valueWithTimestamp() {
+                return valueWithTimestamp(MAP_NULL_VALUE_OFFSET);
+            }
+        }
+
+        private static class ListStateContext extends StateContext {
+            private ListStateContext(TimeProvider timeProvider) {
+                super(StateType.List, timeProvider);
+            }
+
+            @Override
+            void updateValueWithTimestamp(RocksDB db) throws RocksDBException {
+                db.merge(columnFamilyHandle, getASCII(key), list(2, currentTime));
+                db.merge(columnFamilyHandle, getASCII(key), list(2, currentTime + TTL));
+                db.merge(columnFamilyHandle, getASCII(key), valueWithTimestamp());
+                db.merge(columnFamilyHandle, getASCII(key), valueWithTimestamp(0, currentTime + TTL));
+                db.merge(columnFamilyHandle, getASCII(key), valueWithTimestamp());
+                db.merge(columnFamilyHandle, getASCII(key), valueWithTimestamp(0, currentTime + TTL));
+            }
+
+            @Override
+            byte[] unexpiredValue() {
+                ByteBuffer buffer = getByteBufferForList(8);
+                appendValueWithTimestamp(buffer, userValue, currentTime);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime + TTL);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime + TTL);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime + TTL);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime);
+                buffer.put(DELIMITER);
+                appendValueWithTimestamp(buffer, userValue, currentTime + TTL);
+                return buffer.array();
+            }
+
+            @Override
+            byte[] expiredValue() {
+                return list(4, currentTime + TTL);
+            }
+
+            private byte[] list(int numberOfElements, long timestamp) {
+                ByteBuffer buffer = getByteBufferForList(numberOfElements);
+                for (int i = 0; i < numberOfElements; i++) {
+                    appendValueWithTimestamp(buffer, userValue, timestamp);
+                    if (i < numberOfElements - 1) {
+                        buffer.put(DELIMITER);
+                    }
+                }
+                return buffer.array();
+            }
+
+            private ByteBuffer getByteBufferForList(int numberOfElements) {
+                int length = ((LONG_LENGTH + userValue.length() + 1) * numberOfElements) - 1;
+                return ByteBuffer.allocate(length);
+            }
+        }
+    }
+
+}

--- a/src.mk
+++ b/src.mk
@@ -180,6 +180,7 @@ LIB_SOURCES =                                                   \
   utilities/env_mirror.cc                                       \
   utilities/env_timed.cc                                        \
   utilities/geodb/geodb_impl.cc                                 \
+  utilities/flink/flink_compaction_filter.cc                    \
   utilities/leveldb_options/leveldb_options.cc                  \
   utilities/lua/rocks_lua_compaction_filter.cc                  \
   utilities/memory/memory_util.cc                               \
@@ -396,6 +397,7 @@ MAIN_SOURCES =                                                          \
   utilities/document/document_db_test.cc                                \
   utilities/document/json_document_test.cc                              \
   utilities/geodb/geodb_test.cc                                         \
+  utilities/flink/flink_compaction_filter_test.cc                       \
   utilities/lua/rocks_lua_test.cc                                       \
   utilities/memory/memory_test.cc                                       \
   utilities/merge_operators/string_append/stringappend_test.cc          \
@@ -430,6 +432,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/compression_options.cc                        \
   java/rocksjni/env.cc                                        \
   java/rocksjni/env_options.cc                                \
+  java/rocksjni/flink_compactionfilterjni.cc                  \
   java/rocksjni/ingest_external_file_options.cc               \
   java/rocksjni/filter.cc                                     \
   java/rocksjni/iterator.cc                                   \

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4229,7 +4229,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         }
         if (levelMeta.level == 0) {
           for (auto& fileMeta : levelMeta.files) {
-            fprintf(stdout, "Level[%d]: %s(size: %" PRIu64 " bytes)\n",
+            fprintf(stdout, "Level[%d]: %s(size: %" ROCKSDB_PRIszt " bytes)\n",
                     levelMeta.level, fileMeta.name.c_str(), fileMeta.size);
           }
         } else {

--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <iostream>
+#include "utilities/flink/flink_compaction_filter.h"
+
+namespace rocksdb {
+namespace flink {
+
+const char* FlinkCompactionFilter::Name() const {
+  return "FlinkCompactionFilter";
+}
+
+CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
+    int /*level*/, const Slice& /*key*/, ValueType value_type,
+    const Slice& existing_value, std::string* /*new_value*/,
+    std::string* /*skip_until*/) const {
+  const char* data = existing_value.data();
+
+  // too short value to have timestamp at all
+  if (existing_value.size() < TIMESTAMP_BYTE_SIZE) {
+    return  Decision::kKeep;
+  }
+
+  const bool value_state = state_type_ == StateType::Value and value_type == ValueType::kValue;
+  const bool list_entry = state_type_ == StateType::List and value_type == ValueType::kMergeOperand;
+  const bool map_entry = state_type_ == StateType::Map and value_type == ValueType::kValue;
+
+  Decision decision = Decision::kKeep;
+
+  if (value_state or list_entry) {
+    decision = Decide(data, 0);
+  } else if (map_entry) {
+    // too short value to have timestamp for map entry at all
+    if (existing_value.size() < TIMESTAMP_BYTE_SIZE) {
+      decision = Decision::kKeep;
+    } else {
+      decision = Decide(data, FLINK_MAP_STATE_NULL_BYTE_OFFSET); // skip (non-)null flag for map entry
+    }
+  }
+
+  return decision;
+}
+
+CompactionFilter::Decision FlinkCompactionFilter::Decide(const char* ts_bytes, std::size_t offset) const {
+  int64_t timestamp = DeserializeTimestamp(ts_bytes, offset);
+  const int64_t ttlWithoutOverflow = timestamp > 0 ? std::min(JAVA_MAX_LONG - timestamp, ttl_) : ttl_;
+  const int64_t currentTimestamp = time_provider_->CurrentTimestamp();
+  return timestamp + ttlWithoutOverflow <= currentTimestamp ? Decision::kRemove : Decision ::kKeep;
+}
+}  // namespace flink
+}  // namespace rocksdb

--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <algorithm>
 #include <iostream>
 #include "utilities/flink/flink_compaction_filter.h"
 
@@ -14,40 +15,40 @@ const char* FlinkCompactionFilter::Name() const {
 }
 
 CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
-    int /*level*/, const Slice& /*key*/, ValueType value_type,
+    int /*level*/, const Slice& key, ValueType value_type,
     const Slice& existing_value, std::string* /*new_value*/,
     std::string* /*skip_until*/) const {
+  const Config config = *(config_.load());
   const char* data = existing_value.data();
 
+  Debug(logger_, "Call FlinkCompactionFilter::FilterV2");
+  Debug(logger_, "Key: %s, Data: %s, Value type: %d",
+    key.ToString().c_str(), existing_value.ToString(true).c_str(), value_type);
+  Debug(logger_, "Config: state type %d, ttl %d ms, useSystemTime %d, timestamp_offset %d",
+    config.state_type_, config.ttl_, config.useSystemTime_, config.timestamp_offset_);
+
   // too short value to have timestamp at all
-  if (existing_value.size() < TIMESTAMP_BYTE_SIZE) {
-    return  Decision::kKeep;
-  }
+  const bool tooShortValue = existing_value.size() < config.timestamp_offset_ + TIMESTAMP_BYTE_SIZE;
 
-  const bool value_state = state_type_ == StateType::Value and value_type == ValueType::kValue;
-  const bool list_entry = state_type_ == StateType::List and value_type == ValueType::kMergeOperand;
-  const bool map_entry = state_type_ == StateType::Map and value_type == ValueType::kValue;
+  const StateType state_type = config.state_type_;
+  const bool value_state = state_type == StateType::Value && value_type == ValueType::kValue;
+  const bool list_entry = state_type == StateType::List && value_type == ValueType::kMergeOperand;
+  const bool map_entry = state_type == StateType::Map && value_type == ValueType::kValue;
+  const bool toDecide = value_state || list_entry || map_entry;
 
-  Decision decision = Decision::kKeep;
-
-  if (value_state or list_entry) {
-    decision = Decide(data, 0);
-  } else if (map_entry) {
-    // too short value to have timestamp for map entry at all
-    if (existing_value.size() < TIMESTAMP_BYTE_SIZE) {
-      decision = Decision::kKeep;
-    } else {
-      decision = Decide(data, FLINK_MAP_STATE_NULL_BYTE_OFFSET); // skip (non-)null flag for map entry
-    }
-  }
-
+  Decision decision = !tooShortValue && toDecide ?
+    Decide(data, config.timestamp_offset_, config.ttl_, config.useSystemTime_) : Decision::kKeep;
+  Debug(logger_, "Decision: %d", decision);
   return decision;
 }
 
-CompactionFilter::Decision FlinkCompactionFilter::Decide(const char* ts_bytes, std::size_t offset) const {
-  int64_t timestamp = DeserializeTimestamp(ts_bytes, offset);
-  const int64_t ttlWithoutOverflow = timestamp > 0 ? std::min(JAVA_MAX_LONG - timestamp, ttl_) : ttl_;
-  const int64_t currentTimestamp = time_provider_->CurrentTimestamp();
+CompactionFilter::Decision FlinkCompactionFilter::Decide(
+    const char* ts_bytes, std::size_t timestamp_offset, int64_t ttl, bool useSystemTime) const {
+  int64_t timestamp = DeserializeTimestamp(ts_bytes, timestamp_offset);
+  const int64_t ttlWithoutOverflow = timestamp > 0 ? std::min(JAVA_MAX_LONG - timestamp, ttl) : ttl;
+  const int64_t currentTimestamp = CurrentTimestamp(useSystemTime);
+  Debug(logger_, "Last access timestamp: %d ms, ttlWithoutOverflow: %d ms, Current timestamp: %d ms",
+    timestamp, ttlWithoutOverflow, currentTimestamp);
   return timestamp + ttlWithoutOverflow <= currentTimestamp ? Decision::kRemove : Decision ::kKeep;
 }
 }  // namespace flink

--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -16,40 +16,110 @@ const char* FlinkCompactionFilter::Name() const {
 
 CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
     int /*level*/, const Slice& key, ValueType value_type,
-    const Slice& existing_value, std::string* /*new_value*/,
+    const Slice& existing_value, std::string* new_value,
     std::string* /*skip_until*/) const {
   const Config config = *(config_.load());
   const char* data = existing_value.data();
 
-  Debug(logger_, "Call FlinkCompactionFilter::FilterV2");
-  Debug(logger_, "Key: %s, Data: %s, Value type: %d",
-    key.ToString().c_str(), existing_value.ToString(true).c_str(), value_type);
-  Debug(logger_, "Config: state type %d, ttl %d ms, useSystemTime %d, timestamp_offset %d",
+  Debug(logger_.get(),
+    "Call FlinkCompactionFilter::FilterV2 - Key: %s, Data: %s, Value type: %d, "
+    "State type: %d, TTL: %d ms, useSystemTime: %d, timestamp_offset: %d",
+    key.ToString().c_str(), existing_value.ToString(true).c_str(), value_type,
     config.state_type_, config.ttl_, config.useSystemTime_, config.timestamp_offset_);
 
   // too short value to have timestamp at all
   const bool tooShortValue = existing_value.size() < config.timestamp_offset_ + TIMESTAMP_BYTE_SIZE;
 
   const StateType state_type = config.state_type_;
+  const bool value_or_merge = value_type == ValueType::kValue || value_type == ValueType::kMergeOperand;
   const bool value_state = state_type == StateType::Value && value_type == ValueType::kValue;
-  const bool list_entry = state_type == StateType::List && value_type == ValueType::kMergeOperand;
-  const bool map_entry = state_type == StateType::Map && value_type == ValueType::kValue;
-  const bool toDecide = value_state || list_entry || map_entry;
+  const bool list_entry = state_type == StateType::List && value_or_merge;
+  const bool toDecide = value_state || list_entry;
+  const bool list_iter = list_entry && config.list_element_iter_ != nullptr;
 
-  Decision decision = !tooShortValue && toDecide ?
-    Decide(data, config.timestamp_offset_, config.ttl_, config.useSystemTime_) : Decision::kKeep;
-  Debug(logger_, "Decision: %d", decision);
+  Decision decision = Decision::kKeep;
+  if (!tooShortValue && toDecide) {
+    decision = list_iter ?
+            ListDecide(existing_value, config, new_value) :
+            Decide(data, config, config.timestamp_offset_);
+  }
+  Debug(logger_.get(), "Decision: %d", decision);
   return decision;
 }
 
+CompactionFilter::Decision FlinkCompactionFilter::ListDecide(
+        const Slice& existing_value, const Config& config, std::string* new_value) const {
+  config.list_element_iter_->SetListBytes(existing_value);
+  std::size_t offset = 0;
+  while (offset < existing_value.size()) {
+    Decision decision = Decide(existing_value.data(), config, offset + config.timestamp_offset_);
+    if (decision != Decision::kKeep) {
+      offset = ListNextOffset(offset, config.list_element_iter_);
+      if (offset >= JAVA_MAX_SIZE) {
+        return Decision::kKeep;
+      }
+    } else {
+      break;
+    }
+  }
+  if (offset >= existing_value.size()) {
+    return Decision::kRemove;
+  } else if (offset > 0) {
+    SetUnexpiredListValue(existing_value, offset, new_value);
+    return Decision::kChangeValue;
+  }
+  return Decision::kKeep;
+}
+
+std::size_t FlinkCompactionFilter::ListNextOffset(std::size_t offset, ListElementIter* list_element_iter_) const {
+  std::size_t new_offset = list_element_iter_->NextOffset(offset);
+  if (new_offset >= JAVA_MAX_SIZE || new_offset < offset) {
+    Error(logger_.get(), "Wrong next offset in list iterator: %d -> %d",
+          offset, new_offset);
+    new_offset = JAVA_MAX_SIZE;
+  } else {
+    Debug(logger_.get(), "Next offset: %d -> %d",
+          offset, new_offset);
+  }
+  return new_offset;
+}
+
+void FlinkCompactionFilter::SetUnexpiredListValue(
+        const Slice& existing_value, std::size_t offset, std::string* new_value) const {
+  new_value->clear();
+  Slice new_value_slice = Slice(existing_value.data() + offset, existing_value.size() - offset);
+  new_value->assign(new_value_slice.data(), new_value_slice.size());
+  Debug(logger_.get(), "New list value: %s", new_value_slice.ToString(true).c_str());
+}
+
 CompactionFilter::Decision FlinkCompactionFilter::Decide(
-    const char* ts_bytes, std::size_t timestamp_offset, int64_t ttl, bool useSystemTime) const {
+    const char* ts_bytes, const Config& config, const std::size_t timestamp_offset) const {
   int64_t timestamp = DeserializeTimestamp(ts_bytes, timestamp_offset);
-  const int64_t ttlWithoutOverflow = timestamp > 0 ? std::min(JAVA_MAX_LONG - timestamp, ttl) : ttl;
-  const int64_t currentTimestamp = CurrentTimestamp(useSystemTime);
-  Debug(logger_, "Last access timestamp: %d ms, ttlWithoutOverflow: %d ms, Current timestamp: %d ms",
+  const int64_t ttlWithoutOverflow = timestamp > 0 ? std::min(JAVA_MAX_LONG - timestamp, config.ttl_) : config.ttl_;
+  const int64_t currentTimestamp = CurrentTimestamp(config.useSystemTime_);
+  Debug(logger_.get(), "Last access timestamp: %ld ms, ttlWithoutOverflow: %ld ms, Current timestamp: %ld ms",
     timestamp, ttlWithoutOverflow, currentTimestamp);
-  return timestamp + ttlWithoutOverflow <= currentTimestamp ? Decision::kRemove : Decision ::kKeep;
+  return timestamp + ttlWithoutOverflow <= currentTimestamp ? Decision::kRemove : Decision::kKeep;
+}
+
+int64_t FlinkCompactionFilter::DeserializeTimestamp(const char *src, std::size_t offset) const {
+  uint64_t result = 0;
+  for (unsigned long i = 0; i < sizeof(uint64_t); i++) {
+    result |= static_cast<uint64_t>(static_cast<unsigned char>(src[offset + i]))
+            << ((sizeof(int64_t) - 1 - i) * BITS_PER_BYTE);
+  }
+  return static_cast<int64_t>(result);
+}
+
+int64_t FlinkCompactionFilter::CurrentTimestamp(bool useSystemTime) const {
+  using namespace std::chrono;
+  int64_t current_timestamp;
+  if (useSystemTime) {
+    current_timestamp = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+  } else {
+    current_timestamp = current_timestamp_;
+  }
+  return current_timestamp;
 }
 }  // namespace flink
 }  // namespace rocksdb

--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -33,7 +33,33 @@ CompactionFilter::Decision Decide(
          CompactionFilter::Decision::kRemove : CompactionFilter::Decision::kKeep;
 }
 
-std::size_t FlinkCompactionFilter::FixedListElementIter::NextUnexpiredOffset(
+FlinkCompactionFilter::ConfigHolder::ConfigHolder() : config_(const_cast<FlinkCompactionFilter::Config*>(&DISABLED_CONFIG)) {};
+
+FlinkCompactionFilter::ConfigHolder::~ConfigHolder() {
+  Config* config = config_.load();
+  if (config != &DISABLED_CONFIG) {
+    delete config;
+  }
+}
+
+// at the moment Flink configures filters (can be already created) only once when user creates state
+// otherwise it can lead to ListElementFilter leak in Config
+// or race between its delete in Configure() and usage in FilterV2()
+// the method returns true if it was configured before
+bool FlinkCompactionFilter::ConfigHolder::Configure(Config* config) {
+  bool not_configured = GetConfig() == &DISABLED_CONFIG;
+  if (not_configured) {
+    assert(config->query_time_after_num_entries_ >= 0);
+    config_ = config;
+  }
+  return not_configured;
+}
+
+FlinkCompactionFilter::Config* FlinkCompactionFilter::ConfigHolder::GetConfig() {
+  return config_.load();
+}
+
+std::size_t FlinkCompactionFilter::FixedListElementFilter::NextUnexpiredOffset(
         const Slice& list, int64_t ttl, int64_t current_timestamp) const {
   std::size_t offset = 0;
   while (offset < list.size()) {
@@ -55,49 +81,66 @@ const char* FlinkCompactionFilter::Name() const {
   return "FlinkCompactionFilter";
 }
 
+FlinkCompactionFilter::FlinkCompactionFilter(std::shared_ptr<ConfigHolder> config_holder,
+                                             std::unique_ptr<TimeProvider> time_provider) :
+        FlinkCompactionFilter(std::move(config_holder), std::move(time_provider), nullptr) {};
+
+FlinkCompactionFilter::FlinkCompactionFilter(std::shared_ptr<ConfigHolder> config_holder,
+                                             std::unique_ptr<TimeProvider> time_provider,
+                                             std::shared_ptr<Logger> logger) :
+        config_holder_(std::move(config_holder)),
+        time_provider_(std::move(time_provider)),
+        logger_(std::move(logger)),
+        config_cached_(const_cast<Config*>(&DISABLED_CONFIG)) {};
+
+inline void FlinkCompactionFilter::InitConfigIfNotYet() const {
+  const_cast<FlinkCompactionFilter*>(this)->config_cached_ =
+          config_cached_ == &DISABLED_CONFIG ? config_holder_->GetConfig() : config_cached_;
+}
+
 CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
     int /*level*/, const Slice& key, ValueType value_type,
     const Slice& existing_value, std::string* new_value,
     std::string* /*skip_until*/) const {
-  const Config* config = config_holder_->GetConfig();
-  CreateListElementIterIfNull(config->list_element_iter_factory_);
+  InitConfigIfNotYet();
+  CreateListElementFilterIfNull();
+  UpdateCurrentTimestampIfStale();
 
   const char* data = existing_value.data();
 
   Debug(logger_.get(),
     "Call FlinkCompactionFilter::FilterV2 - Key: %s, Data: %s, Value type: %d, "
-    "State type: %d, TTL: %d ms, useSystemTime: %d, timestamp_offset: %d",
+    "State type: %d, TTL: %d ms, timestamp_offset: %d",
     key.ToString().c_str(), existing_value.ToString(true).c_str(), value_type,
-    config->state_type_, config->ttl_, config->useSystemTime_, config->timestamp_offset_);
+    config_cached_->state_type_, config_cached_->ttl_, config_cached_->timestamp_offset_);
 
   // too short value to have timestamp at all
-  const bool tooShortValue = existing_value.size() < config->timestamp_offset_ + TIMESTAMP_BYTE_SIZE;
+  const bool tooShortValue = existing_value.size() < config_cached_->timestamp_offset_ + TIMESTAMP_BYTE_SIZE;
 
-  const StateType state_type = config->state_type_;
+  const StateType state_type = config_cached_->state_type_;
   const bool value_or_merge = value_type == ValueType::kValue || value_type == ValueType::kMergeOperand;
   const bool value_state = state_type == StateType::Value && value_type == ValueType::kValue;
   const bool list_entry = state_type == StateType::List && value_or_merge;
   const bool toDecide = value_state || list_entry;
-  const bool list_iter = list_entry && list_element_iter_;
+  const bool list_filter = list_entry && list_element_filter_;
 
   Decision decision = Decision::kKeep;
   if (!tooShortValue && toDecide) {
-    decision = list_iter ?
-            ListDecide(existing_value, config, new_value) :
-            Decide(data, config->ttl_, config->timestamp_offset_, CurrentTimestamp(config->useSystemTime_), logger_);
+    decision = list_filter ?
+            ListDecide(existing_value, new_value) :
+            Decide(data, config_cached_->ttl_, config_cached_->timestamp_offset_, current_timestamp_, logger_);
   }
   Debug(logger_.get(), "Decision: %d", decision);
   return decision;
 }
 
 CompactionFilter::Decision FlinkCompactionFilter::ListDecide(
-        const Slice& existing_value, const Config* config, std::string* new_value) const {
-  const int64_t current_timestamp = CurrentTimestamp(config->useSystemTime_);
+        const Slice& existing_value, std::string* new_value) const {
   std::size_t offset = 0;
   if (offset < existing_value.size()) {
-    Decision decision = Decide(existing_value.data(), config->ttl_, offset + config->timestamp_offset_, current_timestamp, logger_);
+    Decision decision = Decide(existing_value.data(), config_cached_->ttl_, offset + config_cached_->timestamp_offset_, current_timestamp_, logger_);
     if (decision != Decision::kKeep) {
-      offset = ListNextOffset(existing_value, offset, config->ttl_, current_timestamp);
+      offset = ListNextUnexpiredOffset(existing_value, offset, config_cached_->ttl_);
       if (offset >= JAVA_MAX_SIZE) {
         return Decision::kKeep;
       }
@@ -112,11 +155,11 @@ CompactionFilter::Decision FlinkCompactionFilter::ListDecide(
   return Decision::kKeep;
 }
 
-std::size_t FlinkCompactionFilter::ListNextOffset(
-        const Slice& existing_value, const std::size_t offset, const int64_t ttl, const int64_t current_timestamp) const {
-  std::size_t new_offset = list_element_iter_->NextUnexpiredOffset(existing_value, ttl, current_timestamp);
+std::size_t FlinkCompactionFilter::ListNextUnexpiredOffset(
+        const Slice &existing_value, size_t offset, int64_t ttl) const {
+  std::size_t new_offset = list_element_filter_->NextUnexpiredOffset(existing_value, ttl, current_timestamp_);
   if (new_offset >= JAVA_MAX_SIZE || new_offset < offset) {
-    Error(logger_.get(), "Wrong next offset in list iterator: %d -> %d",
+    Error(logger_.get(), "Wrong next offset in list filter: %d -> %d",
           offset, new_offset);
     new_offset = JAVA_MAX_SIZE;
   } else {
@@ -129,20 +172,14 @@ std::size_t FlinkCompactionFilter::ListNextOffset(
 void FlinkCompactionFilter::SetUnexpiredListValue(
         const Slice& existing_value, std::size_t offset, std::string* new_value) const {
   new_value->clear();
-  Slice new_value_slice = Slice(existing_value.data() + offset, existing_value.size() - offset);
-  new_value->assign(new_value_slice.data(), new_value_slice.size());
-  Debug(logger_.get(), "New list value: %s", new_value_slice.ToString(true).c_str());
-}
-
-int64_t FlinkCompactionFilter::CurrentTimestamp(bool useSystemTime) const {
-  using namespace std::chrono;
-  int64_t current_timestamp;
-  if (useSystemTime) {
-    current_timestamp = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-  } else {
-    current_timestamp = config_holder_->GetCurrentTimestamp();
+  auto new_value_char = existing_value.data() + offset;
+  auto new_value_size = existing_value.size() - offset;
+  new_value->assign(new_value_char, new_value_size);
+  Logger* logger = logger_.get();
+  if (logger && logger->GetInfoLogLevel() <= InfoLogLevel::DEBUG_LEVEL) {
+    Slice new_value_slice = Slice(new_value_char, new_value_size);
+    Debug(logger, "New list value: %s", new_value_slice.ToString(true).c_str());
   }
-  return current_timestamp;
 }
 }  // namespace flink
 }  // namespace rocksdb

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -69,6 +69,8 @@ public:
                     const Slice& existing_value, std::string* new_value,
                     std::string* skip_until) const override;
 
+  bool IgnoreSnapshots() const override { return true; }
+
   void Configure(Config* config) {
       Config* old_config = config_;
       config_ = config;

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -98,11 +98,11 @@ public:
     }
 
     Config GetConfig() {
-        return config_;
+        return config_.load();
     }
 
     std::int64_t GetCurrentTimestamp() {
-      return current_timestamp_;
+      return current_timestamp_.load();
     }
 
   private:

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#include <string>
+#include "rocksdb/compaction_filter.h"
+#include "rocksdb/slice.h"
+#include <chrono>
+#include <functional>
+#include <utility>
+
+namespace rocksdb {
+namespace flink {
+
+#define BITS_PER_BYTE static_cast<size_t>(8)
+#define TIMESTAMP_BYTE_SIZE static_cast<size_t>(8)
+#define FLINK_MAP_STATE_NULL_BYTE_OFFSET static_cast<int>(1)
+#define JAVA_MAX_LONG static_cast<int64_t>(0x7fffffffffffffff)
+
+class TimeProvider {
+public:
+  virtual ~TimeProvider() = default;
+
+  virtual int64_t CurrentTimestamp() const {
+    using namespace std::chrono;
+    return duration_cast< milliseconds >(system_clock::now().time_since_epoch()).count();
+  }
+};
+
+/**
+ * Compaction filter for removing expired Flink state entries with ttl.
+ */
+class FlinkCompactionFilter : public CompactionFilter {
+public:
+ enum StateType {
+     // WARNING!!! Do not change the order of enum entries as it is important for jni translation
+     Value,
+     List,
+     Map
+ };
+ explicit FlinkCompactionFilter(StateType state_type, int64_t ttl) :
+   state_type_(state_type), ttl_(ttl), time_provider_(new TimeProvider()) {}
+ explicit FlinkCompactionFilter(StateType state_type, int64_t ttl, TimeProvider* time_provider) :
+   state_type_(state_type), ttl_(ttl), time_provider_(time_provider) {}
+
+ const char* Name() const override;
+ Decision FilterV2(int level, const Slice& key, ValueType value_type,
+                   const Slice& existing_value, std::string* new_value,
+                   std::string* skip_until) const override;
+
+  ~FlinkCompactionFilter() override { delete time_provider_; }
+
+private:
+  inline Decision Decide(const char* ts_bytes, std::size_t offset) const;
+
+  inline int64_t DeserializeTimestamp(const char *src, std::size_t offset) const {
+    uint64_t result = 0;
+    for (unsigned long i = 0; i < sizeof(uint64_t); i++) {
+      result |= static_cast<uint64_t>(static_cast<unsigned char>(src[offset + i]))
+          << ((sizeof(int64_t) - 1 - i) * BITS_PER_BYTE);
+    }
+    return static_cast<int64_t>(result);
+  }
+
+  StateType state_type_;
+  int64_t ttl_;
+  TimeProvider* time_provider_;
+};
+
+}  // namespace flink
+}  // namespace rocksdb

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -4,56 +4,68 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #pragma once
+#include <atomic>
 #include <string>
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/slice.h"
 #include <chrono>
 #include <functional>
 #include <utility>
+#include <include/rocksdb/env.h>
 
 namespace rocksdb {
 namespace flink {
 
 #define BITS_PER_BYTE static_cast<size_t>(8)
 #define TIMESTAMP_BYTE_SIZE static_cast<size_t>(8)
-#define FLINK_MAP_STATE_NULL_BYTE_OFFSET static_cast<int>(1)
 #define JAVA_MAX_LONG static_cast<int64_t>(0x7fffffffffffffff)
-
-class TimeProvider {
-public:
-  virtual ~TimeProvider() = default;
-
-  virtual int64_t CurrentTimestamp() const {
-    using namespace std::chrono;
-    return duration_cast< milliseconds >(system_clock::now().time_since_epoch()).count();
-  }
-};
 
 /**
  * Compaction filter for removing expired Flink state entries with ttl.
  */
 class FlinkCompactionFilter : public CompactionFilter {
 public:
- enum StateType {
-     // WARNING!!! Do not change the order of enum entries as it is important for jni translation
-     Value,
-     List,
-     Map
- };
- explicit FlinkCompactionFilter(StateType state_type, int64_t ttl) :
-   state_type_(state_type), ttl_(ttl), time_provider_(new TimeProvider()) {}
- explicit FlinkCompactionFilter(StateType state_type, int64_t ttl, TimeProvider* time_provider) :
-   state_type_(state_type), ttl_(ttl), time_provider_(time_provider) {}
+  enum StateType {
+    // WARNING!!! Do not change the order of enum entries as it is important for jni translation
+    Value,
+    List,
+    Map,
+    Disabled
+  };
 
- const char* Name() const override;
- Decision FilterV2(int level, const Slice& key, ValueType value_type,
-                   const Slice& existing_value, std::string* new_value,
-                   std::string* skip_until) const override;
+  struct Config {
+    StateType state_type_;
+    std::size_t timestamp_offset_;
+    int64_t ttl_;
+    bool useSystemTime_;
+  };
 
-  ~FlinkCompactionFilter() override { delete time_provider_; }
+  explicit FlinkCompactionFilter() : logger_(nullptr) {};
+  explicit FlinkCompactionFilter(Logger* logger) : logger_(logger) {};
+
+  const char* Name() const override;
+  Decision FilterV2(int level, const Slice& key, ValueType value_type,
+                    const Slice& existing_value, std::string* new_value,
+                    std::string* skip_until) const override;
+
+  void Configure(Config* config) {
+      Config* old_config = config_;
+      config_ = config;
+      delete old_config;
+  }
+
+  void SetCurrentTimestamp(int64_t current_timestamp) {
+      current_timestamp_ = current_timestamp;
+  }
+
+  ~FlinkCompactionFilter() override {
+      Config* config = config_;
+      delete config;
+      delete logger_;
+  }
 
 private:
-  inline Decision Decide(const char* ts_bytes, std::size_t offset) const;
+  inline Decision Decide(const char* ts_bytes, std::size_t timestamp_offset, int64_t ttl, bool useSystemTime) const;
 
   inline int64_t DeserializeTimestamp(const char *src, std::size_t offset) const {
     uint64_t result = 0;
@@ -64,9 +76,20 @@ private:
     return static_cast<int64_t>(result);
   }
 
-  StateType state_type_;
-  int64_t ttl_;
-  TimeProvider* time_provider_;
+  inline int64_t CurrentTimestamp(bool useSystemTime) const {
+    using namespace std::chrono;
+    int64_t current_timestamp;
+    if (useSystemTime) {
+        current_timestamp = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    } else {
+        current_timestamp = current_timestamp_;
+    }
+    return current_timestamp;
+  }
+
+  std::atomic<Config*> config_ = { new Config{Disabled, 0, std::numeric_limits<int64_t>::max(), true} };
+  std::atomic<std::int64_t> current_timestamp_ = { std::numeric_limits<int64_t>::min() };
+  Logger* logger_;
 };
 
 }  // namespace flink

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -19,18 +19,38 @@ namespace flink {
 #define BITS_PER_BYTE static_cast<size_t>(8)
 #define TIMESTAMP_BYTE_SIZE static_cast<size_t>(8)
 #define JAVA_MAX_LONG static_cast<int64_t>(0x7fffffffffffffff)
+#define JAVA_MAX_SIZE static_cast<std::size_t>(0x7fffffff)
 
 /**
  * Compaction filter for removing expired Flink state entries with ttl.
+ *
+ * Note: this compaction filter is a special implementation, designed for usage only in Apache Flink project.
  */
 class FlinkCompactionFilter : public CompactionFilter {
 public:
   enum StateType {
     // WARNING!!! Do not change the order of enum entries as it is important for jni translation
+    Disabled,
     Value,
-    List,
-    Map,
-    Disabled
+    List
+  };
+
+  class ListElementIter {
+  public:
+    virtual ~ListElementIter() = default;
+    virtual void SetListBytes(const Slice& list) const = 0;
+    virtual std::size_t NextOffset(std::size_t current_offset) const = 0;
+  };
+
+  class FixedListElementIter : public ListElementIter {
+  public:
+    explicit FixedListElementIter(std::size_t fixed_size) : fixed_size_(fixed_size) {}
+    void SetListBytes(const Slice& /* list */) const override {};
+    inline std::size_t NextOffset(std::size_t current_offset) const override {
+        return current_offset + fixed_size_;
+    };
+  private:
+      std::size_t fixed_size_;
   };
 
   struct Config {
@@ -38,10 +58,11 @@ public:
     std::size_t timestamp_offset_;
     int64_t ttl_;
     bool useSystemTime_;
+    ListElementIter* list_element_iter_;
   };
 
   explicit FlinkCompactionFilter() : logger_(nullptr) {};
-  explicit FlinkCompactionFilter(Logger* logger) : logger_(logger) {};
+  explicit FlinkCompactionFilter(std::shared_ptr<Logger> logger) : logger_(std::move(logger)) {};
 
   const char* Name() const override;
   Decision FilterV2(int level, const Slice& key, ValueType value_type,
@@ -51,6 +72,7 @@ public:
   void Configure(Config* config) {
       Config* old_config = config_;
       config_ = config;
+      delete old_config->list_element_iter_;
       delete old_config;
   }
 
@@ -60,36 +82,27 @@ public:
 
   ~FlinkCompactionFilter() override {
       Config* config = config_;
+      delete config->list_element_iter_;
       delete config;
-      delete logger_;
   }
 
 private:
-  inline Decision Decide(const char* ts_bytes, std::size_t timestamp_offset, int64_t ttl, bool useSystemTime) const;
+  Decision ListDecide(const Slice& existing_value, const Config& config, std::string* new_value) const;
 
-  inline int64_t DeserializeTimestamp(const char *src, std::size_t offset) const {
-    uint64_t result = 0;
-    for (unsigned long i = 0; i < sizeof(uint64_t); i++) {
-      result |= static_cast<uint64_t>(static_cast<unsigned char>(src[offset + i]))
-          << ((sizeof(int64_t) - 1 - i) * BITS_PER_BYTE);
-    }
-    return static_cast<int64_t>(result);
-  }
+  inline std::size_t ListNextOffset(std::size_t offset, ListElementIter* list_element_iter_) const;
 
-  inline int64_t CurrentTimestamp(bool useSystemTime) const {
-    using namespace std::chrono;
-    int64_t current_timestamp;
-    if (useSystemTime) {
-        current_timestamp = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    } else {
-        current_timestamp = current_timestamp_;
-    }
-    return current_timestamp;
-  }
+  inline void SetUnexpiredListValue(
+          const Slice& existing_value, std::size_t offset, std::string* new_value) const;
 
-  std::atomic<Config*> config_ = { new Config{Disabled, 0, std::numeric_limits<int64_t>::max(), true} };
+  inline Decision Decide(const char* ts_bytes, const Config& config, std::size_t timestamp_offset) const;
+
+  inline int64_t DeserializeTimestamp(const char *src, std::size_t offset) const;
+
+  inline int64_t CurrentTimestamp(bool useSystemTime) const;
+
+  std::atomic<Config*> config_ = { new Config{Disabled, 0, std::numeric_limits<int64_t>::max(), true, nullptr} };
   std::atomic<std::int64_t> current_timestamp_ = { std::numeric_limits<int64_t>::min() };
-  Logger* logger_;
+  std::shared_ptr<Logger> logger_;
 };
 
 }  // namespace flink

--- a/utilities/flink/flink_compaction_filter.h
+++ b/utilities/flink/flink_compaction_filter.h
@@ -85,15 +85,17 @@ public:
   public:
     ~ConfigHolder() {
       Config* config = config_.load();
-      delete config->list_element_iter_factory_;
-      delete config;
+      if (config != &DISABLED_CONFIG) {
+        delete config->list_element_iter_factory_;
+        delete config;
+      }
     }
 
     // at the moment Flink configures filters (can be already created) only once when user creates state
     // otherwise it can lead to ListElementIter leak in Config
     // or race between its delete in Configure() and usage in FilterV2()
     void Configure(Config* config) {
-      assert(GetConfig()->state_type_ == Disabled);
+      assert(GetConfig() == &DISABLED_CONFIG);
       config_ = config;
     }
 
@@ -110,7 +112,8 @@ public:
     }
 
   private:
-    std::atomic<Config*> config_ = { new Config{Disabled, 0, std::numeric_limits<int64_t>::max(), true, nullptr} };
+    Config DISABLED_CONFIG = Config{Disabled, 0, std::numeric_limits<int64_t>::max(), true, nullptr};
+    std::atomic<Config*> config_ = { &DISABLED_CONFIG };
     std::atomic<std::int64_t> current_timestamp_ = { std::numeric_limits<int64_t>::min() };
   };
 

--- a/utilities/flink/flink_compaction_filter_test.cc
+++ b/utilities/flink/flink_compaction_filter_test.cc
@@ -1,0 +1,135 @@
+// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <random>
+#include "util/testharness.h"
+#include "utilities/flink/flink_compaction_filter.h"
+
+namespace rocksdb {
+namespace flink {
+
+#define VALUE FlinkCompactionFilter::StateType::Value
+#define LIST FlinkCompactionFilter::StateType::List
+#define MAP FlinkCompactionFilter::StateType::Map
+
+#define KVALUE CompactionFilter::ValueType::kValue
+#define KMERGE CompactionFilter::ValueType::kMergeOperand
+
+#define KKEEP CompactionFilter::Decision::kKeep
+#define KREMOVE CompactionFilter::Decision::kRemove
+
+#define EXPIRE (time += ttl + 20)
+
+std::random_device rd; // NOLINT
+std::mt19937 mt(rd()); // NOLINT
+std::uniform_int_distribution<int64_t> rnd(0, JAVA_MAX_LONG); // NOLINT
+
+int64_t time = 0;
+int64_t ttl = 100;
+
+class TestTimeProvider : public TimeProvider {
+public:
+  int64_t CurrentTimestamp() const override { return time; }
+};
+
+Slice key = Slice("key"); // NOLINT
+char data[16];
+std::string stub = ""; // NOLINT
+
+FlinkCompactionFilter::StateType state_type;
+CompactionFilter::ValueType value_type;
+
+void SetTimestamp(int64_t timestamp = time, int offset = 0, char* value = data) {
+  time = timestamp;
+  for (unsigned long i = 0; i < sizeof(uint64_t); i++) {
+    value[offset + i] = static_cast<char>(static_cast<uint64_t>(timestamp)
+            >> ((sizeof(int64_t) - 1 - i) * BITS_PER_BYTE));
+  }
+}
+
+FlinkCompactionFilter init(FlinkCompactionFilter::StateType stype, CompactionFilter::ValueType vtype, int offset = 0) {
+  SetTimestamp(rnd(mt), offset);
+  state_type = stype;
+  value_type = vtype;
+  return FlinkCompactionFilter(state_type, ttl, new TestTimeProvider());
+}
+
+CompactionFilter::Decision decide(FlinkCompactionFilter& filter, size_t data_size = sizeof(data)) {
+  return filter.FilterV2(0, key, value_type, Slice(data, data_size), &stub, &stub);
+}
+
+TEST(FlinkStateTtlTest, CheckStateTypeEnumOrder) { // NOLINT
+  // if the order changes it also needs to be adjusted in Java client:
+  // in org.rocksdb.FlinkCompactionFilter
+  // and in org.rocksdb.FlinkCompactionFilterTest
+  EXPECT_EQ(VALUE, 0);
+  EXPECT_EQ(LIST, 1);
+  EXPECT_EQ(MAP, 2);
+}
+
+TEST(FlinkStateTtlTest, SkipShortDataWithoutTimestamp) { // NOLINT
+  auto filter = init(VALUE, KVALUE);
+  EXPIRE;
+  EXPECT_EQ(decide(filter, TIMESTAMP_BYTE_SIZE - 1), KKEEP);
+}
+
+TEST(FlinkValueStateTtlTest, Unexpired) { // NOLINT
+  auto filter = init(VALUE, KVALUE);
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+TEST(FlinkValueStateTtlTest, Expired) { // NOLINT
+  auto filter = init(VALUE, KVALUE);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KREMOVE);
+}
+
+TEST(FlinkValueStateTtlTest, WrongFilterValueType) { // NOLINT
+  auto filter = init(VALUE, KMERGE);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+TEST(FlinkListStateTtlTest, Unexpired) { // NOLINT
+  auto filter = init(LIST, KMERGE);
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+TEST(FlinkListStateTtlTest, Expired) { // NOLINT
+  auto filter = init(LIST, KMERGE);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KREMOVE);
+}
+
+TEST(FlinkListStateTtlTest, WrongFilterValueType) { // NOLINT
+  auto filter = init(LIST, KVALUE);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+TEST(FlinkMapStateTtlTest, Unexpired) { // NOLINT
+  auto filter = init(MAP, KVALUE, FLINK_MAP_STATE_NULL_BYTE_OFFSET);
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+TEST(FlinkMapStateTtlTest, Expired) { // NOLINT
+  auto filter = init(MAP, KVALUE, FLINK_MAP_STATE_NULL_BYTE_OFFSET);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KREMOVE);
+}
+
+TEST(FlinkMapStateTtlTest, WrongFilterValueType) { // NOLINT
+  auto filter = init(MAP, KMERGE, FLINK_MAP_STATE_NULL_BYTE_OFFSET);
+  EXPIRE;
+  EXPECT_EQ(decide(filter), KKEEP);
+}
+
+} // namespace flink
+} // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/flink/flink_compaction_filter_test.cc
+++ b/utilities/flink/flink_compaction_filter_test.cc
@@ -75,7 +75,8 @@ void Init(FlinkCompactionFilter::StateType stype,
   state_type = stype;
   value_type = vtype;
 
-  config_holder.Configure(FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, false, nullptr});
+  auto config = new FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, false, nullptr};
+  config_holder.Configure(config);
 }
 
 void InitList(CompactionFilter::ValueType vtype, bool first_elem_expired=false, size_t timestamp_offset = 0) {
@@ -86,7 +87,8 @@ void InitList(CompactionFilter::ValueType vtype, bool first_elem_expired=false, 
   value_type = vtype;
 
   auto fixed_len_iter_factory = new FlinkCompactionFilter::FixedListElementIterFactory(LIST_ELEM_FIXED_LEN);
-  config_holder.Configure(FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, false, fixed_len_iter_factory});
+  auto config = new FlinkCompactionFilter::Config{state_type, timestamp_offset, ttl, false, fixed_len_iter_factory};
+  config_holder.Configure(config);
 }
 
 CompactionFilter::Decision decide(size_t data_size = sizeof(data)) {

--- a/utilities/flink/flink_compaction_filter_test.cc
+++ b/utilities/flink/flink_compaction_filter_test.cc
@@ -93,7 +93,8 @@ void InitList(CompactionFilter::ValueType vtype, bool first_elem_expired=false, 
   time = rnd(mt);
   SetTimestamp(first_elem_expired ? time - ttl - 20 : time, timestamp_offset); // elem 1 ts
   SetTimestamp(time, LIST_ELEM_FIXED_LEN + timestamp_offset); // elem 2 ts
-  auto fixed_len_iter_factory = new FlinkCompactionFilter::FixedListElementIterFactory(LIST_ELEM_FIXED_LEN);
+  auto fixed_len_iter_factory =
+          new FlinkCompactionFilter::FixedListElementIterFactory(LIST_ELEM_FIXED_LEN, static_cast<std::size_t>(0));
   Init(LIST, vtype, fixed_len_iter_factory, timestamp_offset);
 }
 


### PR DESCRIPTION
This PR suggests to add a compaction filter for Apache Flink. The filter is supposed to be used for Flink RocksDB state backend. Users can assign time-to-live of state entries in Flink. The expired entries should be removed automatically. The RocksDB compaction filter is a natural place for automatic removal.

In general, the filter is created in deactivated mode when the RocksDB instance is opened in Flink. Flink allows users to create state handles in a lazy way, at any point while Flink job is running. This is the reason why the filter can be atomically configured and activated later after opening RocksDB.

Previously opened in https://github.com/facebook/rocksdb/pull/4463.