### PR TITLE
Extend StringAppendTESTOperator to use string delimiter of variable length

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -123,6 +123,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.SstFileWriter
         org.rocksdb.Statistics
         org.rocksdb.StringAppendOperator
+        org.rocksdb.StringAppendOperatorWithVariableDelimitor
         org.rocksdb.TableFormatConfig
         org.rocksdb.Transaction
         org.rocksdb.TransactionDB
@@ -260,6 +261,7 @@ add_jar(
   src/main/java/org/rocksdb/StatsLevel.java
   src/main/java/org/rocksdb/Status.java
   src/main/java/org/rocksdb/StringAppendOperator.java
+  src/main/java/org/rocksdb/StringAppendOperatorWithVariableDelimitor.java
   src/main/java/org/rocksdb/TableFormatConfig.java
   src/main/java/org/rocksdb/TickerType.java
   src/main/java/org/rocksdb/TransactionalDB.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -60,6 +60,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.VectorMemTableConfig\
 	org.rocksdb.Snapshot\
 	org.rocksdb.StringAppendOperator\
+	org.rocksdb.StringAppendOperatorWithVariableDelimitor\
 	org.rocksdb.WriteBatch\
 	org.rocksdb.WriteBatch.Handler\
 	org.rocksdb.WriteOptions\

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -37,6 +37,28 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator(
 
 /*
  * Class:     org_rocksdb_StringAppendOperator
+ * Method:    newSharedStringAppendTESTOperator
+ * Signature: ([B)J
+ */
+jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendTESTOperator(
+        JNIEnv* env, jclass /*jclazz*/, jbyteArray jdelim) {
+  jboolean has_exception = JNI_FALSE;
+  std::string delim = rocksdb::JniUtil::byteString<std::string>(
+          env, jdelim,
+          [](const char* str, const size_t len) { return std::string(str, len); },
+          &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  auto* sptr_string_append_test_op = new std::shared_ptr<rocksdb::MergeOperator>(
+          rocksdb::MergeOperators::CreateStringAppendTESTOperator(delim));
+  return reinterpret_cast<jlong>(sptr_string_append_test_op);
+}
+
+/*
+ * Class:     org_rocksdb_StringAppendOperator
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "include/org_rocksdb_StringAppendOperator.h"
+#include "include/org_rocksdb_StringAppendOperatorWithVariableDelimitor.h"
 #include "rocksdb/db.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
@@ -37,10 +38,23 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator(
 
 /*
  * Class:     org_rocksdb_StringAppendOperator
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_StringAppendOperator_disposeInternal(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
+  auto* sptr_string_append_op =
+      reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
+  delete sptr_string_append_op;  // delete std::shared_ptr
+}
+
+/*
+ * Class:     org_rocksdb_StringAppendOperatorWithVariableDelimitor
  * Method:    newSharedStringAppendTESTOperator
  * Signature: ([B)J
  */
-jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendTESTOperator(
+jlong Java_org_rocksdb_StringAppendOperatorWithVariableDelimitor_newSharedStringAppendTESTOperator(
         JNIEnv* env, jclass /*jclazz*/, jbyteArray jdelim) {
   jboolean has_exception = JNI_FALSE;
   std::string delim = rocksdb::JniUtil::byteString<std::string>(
@@ -58,14 +72,14 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendTESTOperator(
 }
 
 /*
- * Class:     org_rocksdb_StringAppendOperator
+ * Class:     org_rocksdb_StringAppendOperatorWithVariableDelimitor
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_StringAppendOperator_disposeInternal(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
-                                                           jlong jhandle) {
-  auto* sptr_string_append_op =
-      reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
-  delete sptr_string_append_op;  // delete std::shared_ptr
+void Java_org_rocksdb_StringAppendOperatorWithVariableDelimitor_disposeInternal(JNIEnv* /*env*/,
+                                                                                jobject /*jobj*/,
+                                                                                jlong jhandle) {
+  auto* sptr_string_append_test_op =
+          reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
+  delete sptr_string_append_test_op;  // delete std::shared_ptr
 }

--- a/java/src/main/java/org/rocksdb/StringAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperator.java
@@ -5,8 +5,6 @@
 
 package org.rocksdb;
 
-import java.nio.charset.Charset;
-
 /**
  * StringAppendOperator is a merge operator that concatenates
  * two strings.
@@ -20,19 +18,6 @@ public class StringAppendOperator extends MergeOperator {
         super(newSharedStringAppendOperator(delim));
     }
 
-    public StringAppendOperator(byte[] delim) {
-        super(newSharedStringAppendTESTOperator(delim));
-    }
-
-    public StringAppendOperator(String delim) {
-        this(delim.getBytes());
-    }
-
-    public StringAppendOperator(String delim, Charset charset) {
-        this(delim.getBytes(charset));
-    }
-
     private native static long newSharedStringAppendOperator(final char delim);
-    private native static long newSharedStringAppendTESTOperator(final byte[] delim);
     @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/StringAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperator.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.nio.charset.Charset;
+
 /**
  * StringAppendOperator is a merge operator that concatenates
  * two strings.
@@ -18,6 +20,19 @@ public class StringAppendOperator extends MergeOperator {
         super(newSharedStringAppendOperator(delim));
     }
 
+    public StringAppendOperator(byte[] delim) {
+        super(newSharedStringAppendTESTOperator(delim));
+    }
+
+    public StringAppendOperator(String delim) {
+        this(delim.getBytes());
+    }
+
+    public StringAppendOperator(String delim, Charset charset) {
+        this(delim.getBytes(charset));
+    }
+
     private native static long newSharedStringAppendOperator(final char delim);
+    private native static long newSharedStringAppendTESTOperator(final byte[] delim);
     @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/StringAppendOperatorWithVariableDelimitor.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperatorWithVariableDelimitor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rocksdb;
+
+import java.nio.charset.Charset;
+
+/** Merge operator that concatenates two strings with a delimiter of variable length, string or byte array. */
+public class StringAppendOperatorWithVariableDelimitor extends MergeOperator {
+    public StringAppendOperatorWithVariableDelimitor() {
+        this(',');
+    }
+
+    public StringAppendOperatorWithVariableDelimitor(char delim) {
+        this(Character.toString(delim));
+    }
+
+    public StringAppendOperatorWithVariableDelimitor(byte[] delim) {
+        super(newSharedStringAppendTESTOperator(delim));
+    }
+
+    public StringAppendOperatorWithVariableDelimitor(String delim) {
+        this(delim.getBytes());
+    }
+
+    public StringAppendOperatorWithVariableDelimitor(String delim, Charset charset) {
+        this(delim.getBytes(charset));
+    }
+
+    private native static long newSharedStringAppendTESTOperator(final byte[] delim);
+    @Override protected final native void disposeInternal(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -109,6 +109,34 @@ public class MergeTest {
   }
 
   @Test
+  public void stringDelimiter() throws RocksDBException {
+    stringDelimiter("DELIM");
+    stringDelimiter("");
+  }
+
+  private void stringDelimiter(String delim) throws RocksDBException {
+    try (final StringAppendOperator stringAppendOperator = new StringAppendOperator(delim.getBytes());
+         final Options opt = new Options()
+                 .setCreateIfMissing(true)
+                 .setMergeOperator(stringAppendOperator);
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+      // Writing aa under key
+      db.put("key".getBytes(), "aa".getBytes());
+
+      // Writing bb under key
+      db.merge("key".getBytes(), "bb".getBytes());
+
+      // Writing empty under key
+      db.merge("key".getBytes(), "".getBytes());
+
+      final byte[] value = db.get("key".getBytes());
+      final String strValue = new String(value);
+
+      assertThat(strValue).isEqualTo("aa" + delim + "bb" + delim);
+    }
+  }
+
+  @Test
   public void cFOperatorOption()
       throws InterruptedException, RocksDBException {
     try (final StringAppendOperator stringAppendOperator = new StringAppendOperator();

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -115,7 +115,7 @@ public class MergeTest {
   }
 
   private void stringDelimiter(String delim) throws RocksDBException {
-    try (final StringAppendOperator stringAppendOperator = new StringAppendOperator(delim.getBytes());
+    try (final MergeOperator stringAppendOperator = new StringAppendOperatorWithVariableDelimitor(delim.getBytes());
          final Options opt = new Options()
                  .setCreateIfMissing(true)
                  .setMergeOperator(stringAppendOperator);

--- a/utilities/merge_operators.h
+++ b/utilities/merge_operators.h
@@ -21,6 +21,7 @@ class MergeOperators {
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator();
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator(char delim_char);
   static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator();
+  static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator(std::string delim);
   static std::shared_ptr<MergeOperator> CreateMaxOperator();
   static std::shared_ptr<MergeOperator> CreateBytesXOROperator();
 

--- a/utilities/merge_operators/string_append/stringappend2.h
+++ b/utilities/merge_operators/string_append/stringappend2.h
@@ -13,7 +13,7 @@
 #pragma once
 #include <deque>
 #include <string>
-
+#include <utility>
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/slice.h"
 
@@ -21,18 +21,20 @@ namespace rocksdb {
 
 class StringAppendTESTOperator : public MergeOperator {
  public:
-  // Constructor with delimiter
-  explicit StringAppendTESTOperator(char delim_char);
+  // Constructor with string delimiter
+  explicit StringAppendTESTOperator(std::string delim_str) : delim_(std::move(delim_str)) {};
 
-  virtual bool FullMergeV2(const MergeOperationInput& merge_in,
-                           MergeOperationOutput* merge_out) const override;
+  // Constructor with char delimiter
+  explicit StringAppendTESTOperator(char delim_char) : delim_(std::string(1, delim_char)) {};
 
-  virtual bool PartialMergeMulti(const Slice& key,
-                                 const std::deque<Slice>& operand_list,
-                                 std::string* new_value, Logger* logger) const
-      override;
+  bool FullMergeV2(const MergeOperationInput& merge_in,
+                   MergeOperationOutput* merge_out) const override;
 
-  virtual const char* Name() const override;
+  bool PartialMergeMulti(const Slice& key,
+                         const std::deque<Slice>& operand_list,
+                         std::string* new_value, Logger* logger) const override;
+
+  const char* Name() const override;
 
  private:
   // A version of PartialMerge that actually performs "partial merging".
@@ -41,7 +43,7 @@ class StringAppendTESTOperator : public MergeOperator {
                                const std::deque<Slice>& operand_list,
                                std::string* new_value, Logger* logger) const;
 
-  char delim_;         // The delimiter is inserted between elements
+  std::string delim_;         // The delimiter is inserted between elements
 
 };
 


### PR DESCRIPTION
This PR extend StringAppendTESTOperator class to use std::string delimiter instead of char. char becomes then a custom case of std::string. This allows for delimiter of variable length, including zero length if delimiter is not needed at all and space can be saved. The PR also extends StringAppendOperator in Java API.

original PR in https://github.com/facebook/rocksdb/pull/4806