### PR TITLE
Fix debug mode compile error

### DIFF
--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -131,7 +131,6 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level, const char* format,
     }
 
     assert(format != nullptr);
-    assert(ap != nullptr);
     const std::unique_ptr<char[]> msg = format_str(format, ap);
 
     // pass msg to java callback handler


### PR DESCRIPTION
When compile frocksdb-5.17.2 with DEBUG mode(i.e. DEBUG=1), an error occured:

```
In file included from /usr/include/c++/5/cassert:43:0,
                 from ./include/rocksdb/compaction_filter.h:11,
                 from ./java/./rocksjni/compaction_filter_factory_jnicallback.h:15,
                 from ./java/./rocksjni/portal.h:31,
                 from java/rocksjni/loggerjnicallback.cc:14:
java/rocksjni/loggerjnicallback.cc: In member function ‘virtual void rocksdb::LoggerJniCallback::Logv(rocksdb::InfoLogLevel, const char*, va_list)’:
java/rocksjni/loggerjnicallback.cc:134:18: error: invalid operands of types ‘va_list {aka __va_list}’ and ‘std::nullptr_t’ to binary ‘operator!=’
     assert(ap != nullptr);
```
This PR fixed this error so that frocksdb can be compiled with DEBUG mode.  It will make sure the `jtest` can be ran correctly as well.

This is a cherry-pick from rocksdb, see:  https://github.com/facebook/rocksdb/pull/5836