### PR TITLE
Correct the default write buffer size of java doc (#5670)

### DIFF
--- a/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
@@ -21,7 +21,7 @@ public interface MutableColumnFamilyOptionsInterface
    * Also, a larger write buffer will result in a longer recovery time
    * the next time the database is opened.
    *
-   * Default: 4MB
+   * Default: 64MB
    * @param writeBufferSize the size of write buffer.
    * @return the instance of the current object.
    * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms


### PR DESCRIPTION
Summary:
The actual value of default write buffer size within `rocksdb/include/rocksdb/options.h` is 64 MB, we should correct this value in java doc.

Cherry-pick from https://github.com/facebook/rocksdb/pull/5670
