### PR TITLE
fix DEBUG_LEVEL not set to 0 for the frocksdb* targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,24 @@ ifeq ($(MAKECMDGOALS),rocksdbjavastaticpublish)
 	DEBUG_LEVEL=0
 endif
 
+ifeq ($(MAKECMDGOALS),frocksdbjavastatic)
+	ifneq ($(DEBUG_LEVEL),2)
+		DEBUG_LEVEL=0
+	endif
+endif
+
+ifeq ($(MAKECMDGOALS),frocksdbjavastaticrelease)
+	DEBUG_LEVEL=0
+endif
+
+ifeq ($(MAKECMDGOALS),frocksdbjavastaticreleasedocker)
+        DEBUG_LEVEL=0
+endif
+
+ifeq ($(MAKECMDGOALS),frocksdbjavastaticpublish)
+	DEBUG_LEVEL=0
+endif
+
 # compile with -O2 if debug level is not 2
 ifneq ($(DEBUG_LEVEL), 2)
 OPT += -O2 -fno-omit-frame-pointer

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #-----------------------------------------------
 
-FROCKSDB_VERSION ?= 1.0
+FROCKSDB_VERSION ?= 2.0
 
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)

--- a/RELEASE-FROCKSDB.md
+++ b/RELEASE-FROCKSDB.md
@@ -72,7 +72,7 @@ Run commands:
     cp <path-to-windows-dll>/rocksdbjni-shared.dll java/target/librocksdbjni-win64.dll
     cp <path-to-windows-jar>/rocksdbjni_classes.jar java/target/rocksdbjni_classes.jar
     cp <path-to-ppc64le-lib-so>/librocksdbjni-linux-ppc64le.so java/target/librocksdbjni-linux-ppc64le.so
-    FROCKSDB_VERSION=1.0 make frocksdbjavastaticrelease
+    FROCKSDB_VERSION=2.0 make frocksdbjavastaticrelease
 
 ## Push to maven central
 


### PR DESCRIPTION
This mainly affects the MacOS builds if RELEASE-FROCKSDB.md is followed.

Also, this PR updates the remaining `FROCKSDB_VERSION` definitions to 2.0 (can be overridden during release builds).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/frocksdb/10)
<!-- Reviewable:end -->
