### PR TITLE
Fix MyRocks compile warnings-treated-as-errors on Fedora 30, gcc 9.1.1 (#5553)

### DIFF
--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -232,6 +232,27 @@ class InternalStats {
       }
     }
 
+    CompactionStats& operator=(const CompactionStats& c) {
+      micros = c.micros;
+      bytes_read_non_output_levels = c.bytes_read_non_output_levels;
+      bytes_read_output_level = c.bytes_read_output_level;
+      bytes_written = c.bytes_written;
+      bytes_moved = c.bytes_moved;
+      num_input_files_in_non_output_levels =
+          c.num_input_files_in_non_output_levels;
+      num_input_files_in_output_level = c.num_input_files_in_output_level;
+      num_output_files = c.num_output_files;
+      num_input_records = c.num_input_records;
+      num_dropped_records = c.num_dropped_records;
+      count = c.count;
+
+      int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
+      for (int i = 0; i < num_of_reasons; i++) {
+        counts[i] = c.counts[i];
+      }
+      return *this;
+    }
+
     void Clear() {
       this->micros = 0;
       this->bytes_read_non_output_levels = 0;

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -646,7 +646,7 @@ std::unique_ptr<RangeDelIterator> RangeDelAggregator::NewIterator() {
       iter->AddIterator(stripe.second->NewIterator());
     }
   }
-  return std::move(iter);
+  return iter;
 }
 
 }  // namespace rocksdb

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -52,6 +52,8 @@ struct FileDescriptor {
         smallest_seqno(_smallest_seqno),
         largest_seqno(_largest_seqno) {}
 
+  FileDescriptor(const FileDescriptor& fd) { *this=fd; }
+
   FileDescriptor& operator=(const FileDescriptor& fd) {
     table_reader = fd.table_reader;
     packed_number_and_path_id = fd.packed_number_and_path_id;

--- a/utilities/persistent_cache/persistent_cache_util.h
+++ b/utilities/persistent_cache/persistent_cache_util.h
@@ -48,7 +48,7 @@ class BoundedQueue {
     T t = std::move(q_.front());
     size_ -= t.Size();
     q_.pop_front();
-    return std::move(t);
+    return t;
   }
 
   size_t Size() const {


### PR DESCRIPTION
The following changes were necessary to get rocksdb compiled with gcc 9 (in this case on openSUSE) because it treats a whole bunch of warnings as errors by default. It is a backport of https://github.com/facebook/rocksdb/pull/5553.

Summary:
- Provide assignment operator in `CompactionStats`
- Provide a copy constructor for `FileDescriptor`
- Remove `std::move` from "return std::move(t)" in `BoundedQueue` and `RangeDelAggregator`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/frocksdb/11)
<!-- Reviewable:end -->
