### PR TITLE
Auto roll logger to enforce options.keep_log_file_num immediately after a new file is created (#5370)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 ### Java API Changes
 * Allow rocks java to explicitly create `WriteBufferManager` which could help bound the memory usage of all write buffers.
 * Add more flags for BlockBasedTableConfig, mostly around caching index + filter blocks and partitioned filters. These options could help to minimize the performance impact when bounding the total memory.
+* options.keep_log_file_num will be enforced strictly all the time. File names of all log files will be tracked, which may take significantly amount of memory if options.keep_log_file_num is large and either of options.max_log_file_size or options.log_file_time_to_roll is set.
 
 # 5.17.2-artisans-1.0 (07/02/2019)
 * [Flink TTL] compaction filter for background cleanup of state with time-to-live

--- a/util/auto_roll_logger.cc
+++ b/util/auto_roll_logger.cc
@@ -155,6 +155,11 @@ std::string AutoRollLogger::ValistToString(const char* format,
 
 void AutoRollLogger::LogInternal(const char* format, ...) {
   mutex_.AssertHeld();
+
+  if (!logger_) {
+    return;
+  }
+
   va_list args;
   va_start(args, format);
   logger_->Logv(format, args);
@@ -163,7 +168,10 @@ void AutoRollLogger::LogInternal(const char* format, ...) {
 
 void AutoRollLogger::Logv(const char* format, va_list ap) {
   assert(GetStatus().ok());
-
+  if (!logger_) {
+    return;
+  }
+  
   std::shared_ptr<Logger> logger;
   {
     MutexLock l(&mutex_);
@@ -207,6 +215,10 @@ void AutoRollLogger::WriteHeaderInfo() {
 }
 
 void AutoRollLogger::LogHeader(const char* format, va_list args) {
+  if (!logger_) {
+    return;
+  }
+
   // header message are to be retained in memory. Since we cannot make any
   // assumptions about the data contained in va_list, we will retain them as
   // strings

--- a/util/auto_roll_logger.cc
+++ b/util/auto_roll_logger.cc
@@ -4,12 +4,53 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 #include "util/auto_roll_logger.h"
+#include <algorithm>
+#include "util/filename.h"
+#include "util/logging.h"
 #include "util/mutexlock.h"
 
 namespace rocksdb {
 
 #ifndef ROCKSDB_LITE
 // -- AutoRollLogger
+
+AutoRollLogger::AutoRollLogger(Env* env, const std::string& dbname,
+                               const std::string& db_log_dir,
+                               size_t log_max_size,
+                               size_t log_file_time_to_roll,
+                               size_t keep_log_file_num,
+                               const InfoLogLevel log_level)
+    : Logger(log_level),
+      dbname_(dbname),
+      db_log_dir_(db_log_dir),
+      env_(env),
+      status_(Status::OK()),
+      kMaxLogFileSize(log_max_size),
+      kLogFileTimeToRoll(log_file_time_to_roll),
+      kKeepLogFileNum(keep_log_file_num),
+      cached_now(static_cast<uint64_t>(env_->NowMicros() * 1e-6)),
+      ctime_(cached_now),
+      cached_now_access_count(0),
+      call_NowMicros_every_N_records_(100),
+      mutex_() {
+  Status s = env->GetAbsolutePath(dbname, &db_absolute_path_);
+  if (s.IsNotSupported()) {
+    db_absolute_path_ = dbname;
+  } else {
+    status_ = s;
+  }
+  log_fname_ = InfoLogFileName(dbname_, db_absolute_path_, db_log_dir_);
+  if (env_->FileExists(log_fname_).ok()) {
+    RollLogFile();
+  }
+  GetExistingFiles();
+  ResetLogger();
+  s = TrimOldLogFiles();
+  if (!status_.ok()) {
+    status_ = s;
+  }
+}
+
 Status AutoRollLogger::ResetLogger() {
   TEST_SYNC_POINT("AutoRollLogger::ResetLogger:BeforeNewLogger");
   status_ = env_->NewLogger(log_fname_, &logger_);
@@ -44,6 +85,58 @@ void AutoRollLogger::RollLogFile() {
     now++;
   } while (env_->FileExists(old_fname).ok());
   env_->RenameFile(log_fname_, old_fname);
+  old_log_files_.push(old_fname);
+}
+
+void AutoRollLogger::GetExistingFiles() {
+  {
+    // Empty the queue to avoid duplicated entries in the queue.
+    std::queue<std::string> empty;
+    std::swap(old_log_files_, empty);
+  }
+
+  std::string parent_dir;
+  std::vector<std::string> info_log_files;
+  Status s =
+      GetInfoLogFiles(env_, db_log_dir_, dbname_, &parent_dir, &info_log_files);
+  if (status_.ok()) {
+    status_ = s;
+  }
+  // We need to sort the file before enqueing it so that when we
+  // delete file from the front, it is the oldest file.
+  std::sort(info_log_files.begin(), info_log_files.end());
+
+  for (const std::string& f : info_log_files) {
+    old_log_files_.push(parent_dir + "/" + f);
+  }
+}
+
+Status AutoRollLogger::TrimOldLogFiles() {
+  // Here we directly list info files and delete them through Env.
+  // The deletion isn't going through DB, so there are shortcomes:
+  // 1. the deletion is not rate limited by SstFileManager
+  // 2. there is a chance that an I/O will be issued here
+  // Since it's going to be complicated to pass DB object down to
+  // here, we take a simple approach to keep the code easier to
+  // maintain.
+
+  // old_log_files_.empty() is helpful for the corner case that
+  // kKeepLogFileNum == 0. We can instead check kKeepLogFileNum != 0 but
+  // it's essentially the same thing, and checking empty before accessing
+  // the queue feels safer.
+  while (!old_log_files_.empty() && old_log_files_.size() >= kKeepLogFileNum) {
+    Status s = env_->DeleteFile(old_log_files_.front());
+    // Remove the file from the tracking anyway. It's possible that
+    // DB cleaned up the old log file, or people cleaned it up manually.
+    old_log_files_.pop();
+    // To make the file really go away, we should sync parent directory.
+    // Since there isn't any consistency issue involved here, skipping
+    // this part to avoid one I/O here.
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return Status::OK();
 }
 
 std::string AutoRollLogger::ValistToString(const char* format,
@@ -78,12 +171,19 @@ void AutoRollLogger::Logv(const char* format, va_list ap) {
         (kMaxLogFileSize > 0 && logger_->GetLogFileSize() >= kMaxLogFileSize)) {
       RollLogFile();
       Status s = ResetLogger();
+      Status s2 = TrimOldLogFiles();
+
       if (!s.ok()) {
         // can't really log the error if creating a new LOG file failed
         return;
       }
 
       WriteHeaderInfo();
+
+      if (!s2.ok()) {
+        ROCKS_LOG_WARN(logger.get(), "Fail to trim old info log file: %s",
+                       s2.ToString().c_str());
+      }
     }
 
     // pin down the current logger_ instance before releasing the mutex.
@@ -153,7 +253,8 @@ Status CreateLoggerFromOptions(const std::string& dbname,
   if (options.log_file_time_to_roll > 0 || options.max_log_file_size > 0) {
     AutoRollLogger* result = new AutoRollLogger(
         env, dbname, options.db_log_dir, options.max_log_file_size,
-        options.log_file_time_to_roll, options.info_log_level);
+        options.log_file_time_to_roll, options.keep_log_file_num,
+        options.info_log_level);
     Status s = result->GetStatus();
     if (!s.ok()) {
       delete result;

--- a/util/auto_roll_logger.h
+++ b/util/auto_roll_logger.h
@@ -41,6 +41,10 @@ class AutoRollLogger : public Logger {
   }
 
   size_t GetLogFileSize() const override {
+    if (!logger_) {
+      return 0;
+    }
+
     std::shared_ptr<Logger> logger;
     {
       MutexLock l(&mutex_);

--- a/util/auto_roll_logger.h
+++ b/util/auto_roll_logger.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <list>
+#include <queue>
 #include <string>
 
 #include "port/port.h"
@@ -24,25 +25,8 @@ class AutoRollLogger : public Logger {
  public:
   AutoRollLogger(Env* env, const std::string& dbname,
                  const std::string& db_log_dir, size_t log_max_size,
-                 size_t log_file_time_to_roll,
-                 const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
-      : Logger(log_level),
-        dbname_(dbname),
-        db_log_dir_(db_log_dir),
-        env_(env),
-        status_(Status::OK()),
-        kMaxLogFileSize(log_max_size),
-        kLogFileTimeToRoll(log_file_time_to_roll),
-        cached_now(static_cast<uint64_t>(env_->NowMicros() * 1e-6)),
-        ctime_(cached_now),
-        cached_now_access_count(0),
-        call_NowMicros_every_N_records_(100),
-        mutex_() {
-    env->GetAbsolutePath(dbname, &db_absolute_path_);
-    log_fname_ = InfoLogFileName(dbname_, db_absolute_path_, db_log_dir_);
-    RollLogFile();
-    ResetLogger();
-  }
+                 size_t log_file_time_to_roll, size_t keep_log_file_num,
+                 const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL);
 
   using Logger::Logv;
   void Logv(const char* format, va_list ap) override;
@@ -110,6 +94,11 @@ class AutoRollLogger : public Logger {
   bool LogExpired();
   Status ResetLogger();
   void RollLogFile();
+  // Read all names of old log files into old_log_files_
+  // If there is any error, put the error code in status_
+  void GetExistingFiles();
+  // Delete old log files if it excceeds the limit.
+  Status TrimOldLogFiles();
   // Log message to logger without rolling
   void LogInternal(const char* format, ...);
   // Serialize the va_list to a string
@@ -126,8 +115,14 @@ class AutoRollLogger : public Logger {
   Status status_;
   const size_t kMaxLogFileSize;
   const size_t kLogFileTimeToRoll;
+  const size_t kKeepLogFileNum;
   // header information
   std::list<std::string> headers_;
+  // List of all existing info log files. Used for enforcing number of
+  // info log files.
+  // Full path is stored here. It consumes signifianctly more memory
+  // than only storing file name. Can optimize if it causes a problem.
+  std::queue<std::string> old_log_files_;
   // to avoid frequent env->NowMicros() calls, we cached the current time
   uint64_t cached_now;
   uint64_t ctime_;

--- a/util/filename.h
+++ b/util/filename.h
@@ -169,4 +169,12 @@ extern Status SetIdentityFile(Env* env, const std::string& dbname);
 extern Status SyncManifest(Env* env, const ImmutableDBOptions* db_options,
                            WritableFileWriter* file);
 
+// Return list of file names of info logs in `file_names`.
+// The list only contains file name. The parent directory name is stored
+// in `parent_dir`.
+// `db_log_dir` should be the one as in options.db_log_dir
+extern Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
+                              const std::string& dbname,
+                              std::string* parent_dir,
+                              std::vector<std::string>* file_names);
 }  // namespace rocksdb

--- a/utilities/convenience/info_log_finder.cc
+++ b/utilities/convenience/info_log_finder.cc
@@ -14,35 +14,12 @@
 namespace rocksdb {
 
 Status GetInfoLogList(DB* db, std::vector<std::string>* info_log_list) {
-  uint64_t number = 0;
-  FileType type;
-  std::string path;
-
   if (!db) {
     return Status::InvalidArgument("DB pointer is not valid");
   }
-
+  std::string parent_path;
   const Options& options = db->GetOptions();
-  if (!options.db_log_dir.empty()) {
-    path = options.db_log_dir;
-  } else {
-    path = db->GetName();
-  }
-  InfoLogPrefix info_log_prefix(!options.db_log_dir.empty(), db->GetName());
-  auto* env = options.env;
-  std::vector<std::string> file_names;
-  Status s = env->GetChildren(path, &file_names);
-
-  if (!s.ok()) {
-    return s;
-  }
-
-  for (auto f : file_names) {
-    if (ParseFileName(f, &number, info_log_prefix.prefix, &type) &&
-        (type == kInfoLogFile)) {
-      info_log_list->push_back(f);
-    }
-  }
-  return Status::OK();
+  return GetInfoLogFiles(options.env, options.db_log_dir, db->GetName(),
+                         &parent_path, info_log_list);
 }
 }  // namespace rocksdb


### PR DESCRIPTION
This is a backport of https://github.com/facebook/rocksdb/pull/5370 which makes the rolling logger really work and really restrains the total amount of log files and size.

Summary:
Right now, with auto roll logger, options.keep_log_file_num enforcement is triggered by events like DB reopen or full obsolete scan happens. In the mean time, the size and number of log files can grow without a limit. We put a stronger enforcement to the option, so that the number of log files can always under control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/frocksdb/12)
<!-- Reviewable:end -->
