### PR TITLE
fix unable to fetch EPEL repository during Vagrant linux build

### DIFF
--- a/java/crossbuild/build-linux-centos.sh
+++ b/java/crossbuild/build-linux-centos.sh
@@ -7,6 +7,7 @@ sudo rm -f /etc/yum/vars/releasever
 
 # enable EPEL
 sudo yum -y install epel-release
+sudo sed -i "s/mirrorlist=https/mirrorlist=http/" /etc/yum.repos.d/epel.repo
 
 # install all required packages for rocksdb that are available through yum
 sudo yum -y install openssl java-1.7.0-openjdk-devel zlib-devel bzip2-devel lz4-devel snappy-devel libzstd-devel jemalloc-devel


### PR DESCRIPTION
Previously, the linux build was failing with
```
    linux32: Error: Cannot retrieve metalink for repository: epel. Please verify its path and try again
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

The reason seems to be some outdated certificate, but updating `ca-certificates` did not help. Using `http` instead of `https` seems to be the best way to solve it, for now. RocksDB itself updated to a more recent CentOS version (6.10 instead of 6.7) in https://github.com/facebook/rocksdb/commit/1e9c8d42a01e6b1e5f6fbae6c295a37358d42e35 but we may not want to diverge too much from the RocksDB version we are based on.

Please note that we are not reducing security here since all Packages are still signed with a (known) GPG key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/frocksdb/13)
<!-- Reviewable:end -->
