### PR TITLE
Use https for Maven Central url

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -317,7 +317,7 @@ if (DEFINED CUSTOM_REPO_URL)
   set(CENTRAL_REPO_URL ${CUSTOM_REPO_URL}/)
 else ()
   set(SEARCH_REPO_URL "http://search.maven.org/remotecontent?filepath=")
-  set(CENTRAL_REPO_URL "http://central.maven.org/maven2/")
+  set(CENTRAL_REPO_URL "https://repo1.maven.org/maven2/")
 endif()
 
 if(NOT EXISTS ${JAVA_JUNIT_JAR})

--- a/java/Makefile
+++ b/java/Makefile
@@ -191,7 +191,7 @@ ifneq ($(DEBUG_LEVEL),0)
 endif
 
 SEARCH_REPO_URL?=http://search.maven.org/remotecontent?filepath=
-CENTRAL_REPO_URL?=http://central.maven.org/maven2/
+CENTRAL_REPO_URL?=https://repo1.maven.org/maven2/
 
 clean:
 	$(AM_V_at)rm -rf include/*


### PR DESCRIPTION
The jar is failed building, because that Maven central only supports
HTTPS from 1/15/2020 now. Use https url instead.

https://blog.sonatype.com/central-repository-moving-to-https