### PR TITLE
Fix bug in MultiRead() coalescing introduced in 4fc216649d

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -194,7 +194,7 @@ bool TryMerge(FSReadRequest* dest, const FSReadRequest& src) {
   size_t src_offset = static_cast<size_t>(src.offset);
   size_t dest_end = End(*dest);
   size_t src_end = End(src);
-  if (std::max(dest_offset, dest_offset) > std::min(dest_end, src_end)) {
+  if (std::max(dest_offset, src_offset) > std::min(dest_end, src_end)) {
     return false;
   }
   dest->offset = static_cast<uint64_t>(std::min(dest_offset, src_offset));


### PR DESCRIPTION
This cherry pick from RocksDB repo.

Summary:
TryMerge() overzealously creates one huge file read request in an attempt to merge smaller disjoint requests. For example, ~30 input requests of ~100 bytes output as 1 request of 100 MiB causing alarmingly large read throughputs to be repeatedly observed by the environment.

Signed-off-by: Jason Volk <jason@zemos.net>

Pull Request resolved: https://github.com/facebook/rocksdb/pull/6979

Reviewed By: siying

Differential Revision: D22668892

Pulled By: cheng-chang

fbshipit-source-id: 7506fe9621b7f1a747dadf6b8ddb1b1a141c1937