### PR TITLE
[FLINK-21411] Upgrade bzip2 version from 1.0.6 to 1.0.8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # FRocksdb Change Log
 
+# 5.17.2-ververica-2.1 (07/20/2021)
+* Bump the version of bzip2 to 1.0.8
+
 # 5.17.2-artisans-2.0 (11/26/2019)
 ### Java API Changes
 * Allow rocks java to explicitly create `WriteBufferManager` which could help bound the memory usage of all write buffers.

--- a/Makefile
+++ b/Makefile
@@ -1652,9 +1652,9 @@ SHA256_CMD = sha256sum
 ZLIB_VER ?= 1.2.11
 ZLIB_SHA256 ?= c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 ZLIB_DOWNLOAD_BASE ?= http://zlib.net
-BZIP2_VER ?= 1.0.6
-BZIP2_SHA256 ?= a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
-BZIP2_DOWNLOAD_BASE ?= https://web.archive.org/web/20180624184835/http://www.bzip.org
+BZIP2_VER ?= 1.0.8
+BZIP2_SHA256 ?= ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+BZIP2_DOWNLOAD_BASE ?= https://sourceware.org/pub/bzip2
 SNAPPY_VER ?= 1.1.4
 SNAPPY_SHA256 ?= 134bfe122fd25599bb807bb8130e7ba6d9bdb851e0b16efcb83ac4f5d0b70057
 SNAPPY_DOWNLOAD_BASE ?= https://github.com/google/snappy/releases/download
@@ -1713,7 +1713,7 @@ libz.a:
 
 libbz2.a:
 	-rm -rf bzip2-$(BZIP2_VER)
-	curl -O -L ${BZIP2_DOWNLOAD_BASE}/$(BZIP2_VER)/bzip2-$(BZIP2_VER).tar.gz
+	curl -O -L ${BZIP2_DOWNLOAD_BASE}/bzip2-$(BZIP2_VER).tar.gz
 	BZIP2_SHA256_ACTUAL=`$(SHA256_CMD) bzip2-$(BZIP2_VER).tar.gz | cut -d ' ' -f 1`; \
 	if [ "$(BZIP2_SHA256)" != "$$BZIP2_SHA256_ACTUAL" ]; then \
 		echo bzip2-$(BZIP2_VER).tar.gz checksum mismatch, expected=\"$(BZIP2_SHA256)\" actual=\"$$BZIP2_SHA256_ACTUAL\"; \

--- a/java/crossbuild/docker-build-linux-centos.sh
+++ b/java/crossbuild/docker-build-linux-centos.sh
@@ -8,12 +8,21 @@ cd /rocksdb-local
 
 # Use scl devtoolset if available (i.e. CentOS <7)
 if hash scl 2>/dev/null; then
-	scl enable devtoolset-2 'make jclean clean'
-	scl enable devtoolset-2 'PORTABLE=1 make rocksdbjavastatic'
+	if scl --list | grep -q 'devtoolset-7'; then
+		scl enable devtoolset-7 'make jclean clean'
+		scl enable devtoolset-7 'PORTABLE=1 make -j2 rocksdbjavastatic'
+
+	elif scl --list | grep -q 'devtoolset-2'; then
+		scl enable devtoolset-2 'make jclean clean'
+		scl enable devtoolset-2 'PORTABLE=1 make -j2 rocksdbjavastatic'
+
+	else
+		echo "Could not find devtoolset"
+		exit 1;
+	fi
 else
 	make jclean clean
-        PORTABLE=1 make rocksdbjavastatic
+        PORTABLE=1 make -j2 rocksdbjavastatic
 fi
 
 cp java/target/librocksdbjni-linux*.so java/target/rocksdbjni-*-linux*.jar /rocksdb-host/java/target
-


### PR DESCRIPTION
This PR upgrades bzip2 version from 1.0.6 to 1.0.8.

And since we use docker to release FRocksDB, update related scripts.