### PR TITLE
fix(CompactionFilter): avoid expensive `ToString` call when not in Debug

### DIFF
--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -117,13 +117,16 @@ CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
 
   const char* data = existing_value.data();
 
-  Debug(logger_.get(),
+  if (logger_ && logger_->GetInfoLogLevel() <= InfoLogLevel::DEBUG_LEVEL) {
+    Debug(
+        logger_.get(),
         "Call FlinkCompactionFilter::FilterV2 - Key: %s, Data: %s, Value type: "
         "%d, "
         "State type: %d, TTL: %" PRId64 " ms, timestamp_offset: %zu",
         key.ToString().c_str(), existing_value.ToString(true).c_str(),
         value_type, config_cached_->state_type_, config_cached_->ttl_,
         config_cached_->timestamp_offset_);
+  }
 
   // too short value to have timestamp at all
   const bool tooShortValue =


### PR DESCRIPTION
Hello all!

This fix aims at optimizing the usage of the compaction filter in Flink. We notice that 20% of our CPU usage came from this ToString call when running with production load, this PR aims to avoid calling `ToString` in the compaction filter when it's not needed.