### PR TITLE
[FLINK-23346]Avoid core dump when rethrowing the exception

### DIFF
--- a/java/rocksjni/flink_compactionfilterjni.cc
+++ b/java/rocksjni/flink_compactionfilterjni.cc
@@ -22,8 +22,9 @@ class JniCallbackBase : public ROCKSDB_NAMESPACE::JniCallback {
  protected:
   inline void CheckAndRethrowException(JNIEnv* env) const {
     if (env->ExceptionCheck()) {
+      jthrowable obj = env->ExceptionOccurred();
       env->ExceptionDescribe();
-      env->Throw(env->ExceptionOccurred());
+      env->Throw(obj);
     }
   }
 };


### PR DESCRIPTION
This fixes [FLINK-23346](https://issues.apache.org/jira/browse/FLINK-23346)